### PR TITLE
Add `pure`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,12 @@ _coming soon_
 
 ## What's included? ##
 
-Importing Runes introduces 3 new operators:
+Importing Runes introduces 3 new operators and one global function:
 
 - `<^>` (pronounced "map")
 - `<*>` (pronounced "apply")
 - `>>-` (pronounced "flatMap")
+- `pure` (pronounced "pure")
 
 We also include default implementations for Optional with the following type signatures:
 
@@ -26,4 +27,5 @@ We also include default implementations for Optional with the following type sig
 public func <^><T, U>(f: T -> U, a: T?) -> U?
 public func <*><T, U>(f: (T -> U)?, a: T?) -> U?
 public func >>-<T, U>(a: T?, f: T -> U?) -> U?
+public func pure<T>(a: T) -> T?
 ```

--- a/README.md
+++ b/README.md
@@ -21,11 +21,19 @@ Importing Runes introduces 3 new operators and one global function:
 - `>>-` (pronounced "flatMap")
 - `pure` (pronounced "pure")
 
-We also include default implementations for Optional with the following type signatures:
+We also include default implementations for Optional and Array with the
+following type signatures:
 
 ```swift
+// Optional:
 public func <^><T, U>(f: T -> U, a: T?) -> U?
 public func <*><T, U>(f: (T -> U)?, a: T?) -> U?
 public func >>-<T, U>(a: T?, f: T -> U?) -> U?
 public func pure<T>(a: T) -> T?
+
+// Array:
+public func <^><T, U>(f: T -> U, a: [T]) -> [U]
+public func <*><T, U>(fs: [T -> U], a: [T]) -> [U]
+public func >>-<T, U>(a: [T], f: T -> [U]) -> [U]
+public func pure<T>(a: T) -> [T]
 ```

--- a/Source/Array.swift
+++ b/Source/Array.swift
@@ -10,6 +10,10 @@ public func >>-<T, U>(a: [T], f: T -> [U]) -> [U] {
     return a.flatMap(f)
 }
 
+public func pure<T>(a: T) -> [T] {
+    return [a]
+}
+
 extension Array {
     func apply<U>(fs: [T -> U]) -> [U] {
         return fs.flatMap { f in self.map(f) }

--- a/Source/Optional.swift
+++ b/Source/Optional.swift
@@ -10,6 +10,10 @@ public func >>-<T, U>(a: T?, f: T -> U?) -> U? {
     return a.flatMap(f)
 }
 
+public func pure<T>(a: T) -> T? {
+    return .Some(a)
+}
+
 extension Optional {
     func apply<U>(f: (T -> U)?) -> U? {
         switch (self, f) {


### PR DESCRIPTION
`pure` wraps a value in a minimal context. In this case, we've
implemented it for `Optional`, which wraps the given value in `.Some`,
and for `Array`, which wraps the given value in a new array.
