### PR TITLE
Prevent incorrect use of `flatMap`

### DIFF
--- a/Source/Array.swift
+++ b/Source/Array.swift
@@ -40,6 +40,11 @@ public func >>-<T, U>(a: [T], f: T -> [U]) -> [U] {
     return a.flatMap(f)
 }
 
+@availability(*, unavailable, message="function (T -> U) is not equal to function (T -> [U])")
+public func >>-<T, U>(a: [T], f: T -> U) -> [U] {
+    return a.map(f)
+}
+
 /**
     Wrap a value in a minimal context of []
 

--- a/Source/Array.swift
+++ b/Source/Array.swift
@@ -40,7 +40,7 @@ public func >>-<T, U>(a: [T], f: T -> [U]) -> [U] {
     return a.flatMap(f)
 }
 
-@availability(*, unavailable, message="function (T -> U) is not equal to function (T -> [U])")
+@availability(*, unavailable, message="function (T -> U) does not return [U], perhaps you meant f <^> val")
 public func >>-<T, U>(a: [T], f: T -> U) -> [U] {
     return a.map(f)
 }

--- a/Source/Optional.swift
+++ b/Source/Optional.swift
@@ -43,6 +43,11 @@ public func >>-<T, U>(a: T?, f: T -> U?) -> U? {
     return a.flatMap(f)
 }
 
+@availability(*, unavailable, message="function (T -> U) is not equal to function (T -> U?)")
+public func >>-<T, U>(a: T?, f: T -> U) -> U? {
+    return a.map(f)
+}
+
 /**
     Wrap a value in a minimal context of .Some
 

--- a/Source/Optional.swift
+++ b/Source/Optional.swift
@@ -43,7 +43,7 @@ public func >>-<T, U>(a: T?, f: T -> U?) -> U? {
     return a.flatMap(f)
 }
 
-@availability(*, unavailable, message="function (T -> U) is not equal to function (T -> U?)")
+@availability(*, unavailable, message="function (T -> U) does not return U?, perhaps you meant f <^> val")
 public func >>-<T, U>(a: T?, f: T -> U) -> U? {
     return a.map(f)
 }


### PR DESCRIPTION
Swift will happily coerce functions of the type `A -> B` into functions of the
type `A -> B?`. That means that using `flatMap` with a function that doesn't
return an optional will compile. But then at runtime, you will run into weird
behaviour that you don't expect, or worse, Swift will segfault.

In order to prevent these problems from happening in the future, we're going
to throw errors ourselves if `flatMap` is used incorrectly with a message
letting the user know that the type of the function isn't correct. Using a
default (but ultimately unused) implementation of `map` will push people in
the right direction if they go digging.

Credit to @mattrubin for the idea: 
https://github.com/thoughtbot/Argo/issues/34#issuecomment-70166588
