### PR TITLE
Swift 1.2 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ Indecipherable symbols that some people claim have actual meaning.
 
 ## Installation ##
 
+Note that as of Runes 1.2, [pre-built binaries][releases] will assume Swift
+1.2. Runes 1.1.1 is considered stable for long-term use, and `master` is 100%
+source compatible with Swift 1.1.
+
+[releases]: https://github.com/thoughtbot/Runes/releases
+
 ### [Carthage](https://github.com/Carthage/Carthage) ##
 
 `github "thoughtbot/runes"`

--- a/Runes.podspec
+++ b/Runes.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = 'Runes'
-  spec.version = '1.1.1'
+  spec.version = '1.2.0'
   spec.summary = 'Functional operators for Swift'
   spec.homepage = 'https://github.com/thoughtbot/runes'
   spec.license = { :type => 'MIT', :file => 'LICENSE' }

--- a/Source/Info.plist
+++ b/Source/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1</string>
+	<string>1.2.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
I'd like to bump the version number for Runes to 1.2 in order to be able
to offer pre-built binaries that work with Swift 1.2. There aren't any
source code changes, so this won't affect people building directly
(CocoaPods or Submodules), but it will make versioning easier in
libraries that want to use Carthage and work in Swift 1.2
