### PR TITLE
Remove type-coerced flatMap guards

### DIFF
--- a/Source/Array.swift
+++ b/Source/Array.swift
@@ -40,11 +40,6 @@ public func >>-<T, U>(a: [T], f: T -> [U]) -> [U] {
     return a.flatMap(f)
 }
 
-@availability(*, unavailable, message="function (T -> U) does not return [U], perhaps you meant f <^> val")
-public func >>-<T, U>(a: [T], f: T -> U) -> [U] {
-    return a.map(f)
-}
-
 /**
 flatMap a function over an array of values (right associative)
 
@@ -57,11 +52,6 @@ apply a function to each value of an array and flatten the resulting array
 */
 public func -<<<T, U>(f: T -> [U], a: [T]) -> [U] {
   return a.flatMap(f)
-}
-
-@availability(*, unavailable, message="function (T -> U) does not return [U], perhaps you meant f <^> val")
-public func -<<<T, U>(f: T -> U, a: [T]) -> [U] {
-  return a.map(f)
 }
 
 /**

--- a/Source/Optional.swift
+++ b/Source/Optional.swift
@@ -43,11 +43,6 @@ public func >>-<T, U>(a: T?, f: T -> U?) -> U? {
     return a.flatMap(f)
 }
 
-@availability(*, unavailable, message="function (T -> U) does not return U?, perhaps you meant f <^> val")
-public func >>-<T, U>(a: T?, f: T -> U) -> U? {
-  return a.map(f)
-}
-
 /**
 flatMap a function over an optional value (right associative)
 
@@ -61,11 +56,6 @@ flatMap a function over an optional value (right associative)
 */
 public func -<<<T, U>(f: T -> U?, a: T?) -> U? {
   return a.flatMap(f)
-}
-
-@availability(*, unavailable, message="function (T -> U) does not return U?, perhaps you meant f <^> val")
-public func -<<<T, U>(f: T -> U, a: T?) -> U? {
-    return a.map(f)
 }
 
 /**


### PR DESCRIPTION
Resolves #13.

This change effectively undoes a previous change put in place to guard
against a bug in the Swift compiler before 1.2 which would
automatically coerce functions of the type `A -> B` to `A -> B?` (See
#5 for more details).

I’ve tested this against Xcode 6.3 beta 2 by trying to flatMap a
function of the type `String -> String` and I get the following
compiler error:

> Function signature ‘(String) -> String’ is not compatible with
> expected type ‘String -> String?’

I think we’re good here, folks.
