### PR TITLE
[RFC] Should Runes follow the operator precedence defined by Haskell?

### DIFF
--- a/Source/Operators.swift
+++ b/Source/Operators.swift
@@ -1,4 +1,4 @@
-infix operator <^> { associativity left precedence 155 }
-infix operator <*> { associativity left precedence 155 }
-infix operator >>- { associativity left precedence 150 }
-infix operator -<< { associativity right precedence 150 }
+infix operator <^> { associativity left precedence 130 }
+infix operator <*> { associativity left precedence 130 }
+infix operator >>- { associativity left precedence 100 }
+infix operator -<< { associativity right precedence 100 }

--- a/Source/Operators.swift
+++ b/Source/Operators.swift
@@ -1,4 +1,4 @@
-infix operator <^> { associativity left }
-infix operator <*> { associativity left }
+infix operator <^> { associativity left precedence 155 }
+infix operator <*> { associativity left precedence 155 }
 infix operator >>- { associativity left precedence 150 }
 infix operator -<< { associativity right precedence 150 }


### PR DESCRIPTION
I'm currently working on adding an implementation of `<^>` to Madness (https://github.com/robrix/Madness/pull/86), and so in the interests of keeping things standardised I thought I'd check how Runes defines the operator. I also checked how the precedence is defined in Haskell:

```
Prelude Control.Applicative> :i (<$>)
(<$>) :: Functor f => (a -> b) -> f a -> f b
    -- Defined in ‘Data.Functor’
infixl 4 <$>
Prelude Control.Applicative> :i (<*>)
class Functor f => Applicative (f :: * -> *) where
  ...
  (<*>) :: f (a -> b) -> f a -> f b
  ...
    -- Defined in ‘Control.Applicative’
infixl 4 <*>
Prelude Control.Applicative> :i (>>=)
class Monad (m :: * -> *) where
  (>>=) :: m a -> (a -> m b) -> m b
  ...
    -- Defined in ‘GHC.Base’
infixl 1 >>=
```

So in Haskell, `<$>` (`infixl 4`) and `<*>` (`infixl 4`) have higher precedence than `>>=` (`infixl 1`). However, Runes doesn't specify an explicit precedence, and the default is lower than the `150` defined for `>>-`.

What do you think about setting an explicit precedence for `<^>` and `<*>` that's higher than `>>-`? I've somewhat arbitrarily selected `155` here, but it could be any value really.
