### PR TITLE
[WIP] Comonadic extend for Optional

### DIFF
--- a/Source/Operators.swift
+++ b/Source/Operators.swift
@@ -2,3 +2,4 @@ infix operator <^> { associativity left precedence 130 }
 infix operator <*> { associativity left precedence 130 }
 infix operator >>- { associativity left precedence 100 }
 infix operator -<< { associativity right precedence 100 }
+infix operator <<- { associativity right precedence 100 }

--- a/Source/Optional.swift
+++ b/Source/Optional.swift
@@ -4,6 +4,14 @@ public func <<-<T,U>(f: T? -> U, a: T?) -> U? {
     case .None: return .None
     }
 }
+
+public func duplicate<T>(a: T?) -> T?? {
+    switch a {
+    case .None: return .None
+    default: return .Some(a)
+    }
+}
+
 /**
     map a function over an optional value
 

--- a/Source/Optional.swift
+++ b/Source/Optional.swift
@@ -1,3 +1,9 @@
+public func <<-<T,U>(f: T? -> U, a: T?) -> U? {
+    switch a {
+    case .Some(_): return .Some(f(a))
+    case .None: return .None
+    }
+}
 /**
     map a function over an optional value
 

--- a/Tests/Tests/OptionalSpec.swift
+++ b/Tests/Tests/OptionalSpec.swift
@@ -13,6 +13,36 @@ private func generateOptional(block: String? -> Bool) -> FOXGenerator {
 class OptionalSpec: QuickSpec {
     override func spec() {
         describe("Optional") {
+            describe("extend") {
+                // extend f = fmap f . duplicate
+                it("obeys the comonadic extend law") {
+                    let testFunc: String? -> String = { string in
+                        if let s = string {
+                            return "YES"
+                        } else {
+                            return "NO"
+                        }
+                    }
+
+                    let duplicate: String? -> String?? = { string in
+                        if let s = string {
+                            return .Some(string)
+                        } else {
+                            return .None
+                        }
+                    }
+
+                    let property = generateOptional() { optional in
+                        let lhs = testFunc <<- optional
+                        let rhs = compose(duplicate, curry(<^>)(testFunc))(optional)
+                        
+                        return lhs == rhs
+                    }
+
+                    expect(property).to(hold())
+                }
+            }
+
             describe("map") {
                 // fmap id = id
                 it("obeys the identity law") {

--- a/Tests/Tests/OptionalSpec.swift
+++ b/Tests/Tests/OptionalSpec.swift
@@ -24,14 +24,6 @@ class OptionalSpec: QuickSpec {
                         }
                     }
 
-                    let duplicate: String? -> String?? = { string in
-                        if let s = string {
-                            return .Some(string)
-                        } else {
-                            return .None
-                        }
-                    }
-
                     let property = generateOptional() { optional in
                         let lhs = testFunc <<- optional
                         let rhs = compose(duplicate, curry(<^>)(testFunc))(optional)


### PR DESCRIPTION
I'm not quite sure that what I've done makes any sense, but I was reading about the [Comonad](https://hackage.haskell.org/package/comonad-4.2.6/docs/Control-Comonad.html) typeclass in Haskell, and thought I could bring the `extend :: (w a -> b ) -> w a -> w b` operator to Runes.

I wanted to open this to gauge interest, and indeed see if what I'm doing even makes sense... I implemented `extend` for optionals and checked that it obeyed the law `extend f = fmap f . duplicate`, where `duplicate` is the dual of monadic `join`.
