### PR TITLE
Add space to operator definitions, to improve readability.

### DIFF
--- a/Source/Array.swift
+++ b/Source/Array.swift
@@ -8,7 +8,7 @@
 
     - returns: A value of type `[U]`
 */
-public func <^><T, U>(f: T -> U, a: [T]) -> [U] {
+public func <^> <T, U>(f: T -> U, a: [T]) -> [U] {
     return a.map(f)
 }
 
@@ -22,7 +22,7 @@ public func <^><T, U>(f: T -> U, a: [T]) -> [U] {
 
     - returns: A value of type `[U]`
 */
-public func <*><T, U>(fs: [T -> U], a: [T]) -> [U] {
+public func <*> <T, U>(fs: [T -> U], a: [T]) -> [U] {
     return a.apply(fs)
 }
 
@@ -36,7 +36,7 @@ public func <*><T, U>(fs: [T -> U], a: [T]) -> [U] {
 
     - returns: A value of type `[U]`
 */
-public func >>-<T, U>(a: [T], @noescape f: T -> [U]) -> [U] {
+public func >>- <T, U>(a: [T], @noescape f: T -> [U]) -> [U] {
     return a.flatMap(f)
 }
 
@@ -50,7 +50,7 @@ public func >>-<T, U>(a: [T], @noescape f: T -> [U]) -> [U] {
 
     - returns: A value of type `[U]`
 */
-public func -<<<T, U>(@noescape f: T -> [U], a: [T]) -> [U] {
+public func -<< <T, U>(@noescape f: T -> [U], a: [T]) -> [U] {
   return a.flatMap(f)
 }
 

--- a/Source/Optional.swift
+++ b/Source/Optional.swift
@@ -9,7 +9,7 @@
 
     - returns: A value of type `Optional<U>`
 */
-public func <^><T, U>(@noescape f: T -> U, a: T?) -> U? {
+public func <^> <T, U>(@noescape f: T -> U, a: T?) -> U? {
     return a.map(f)
 }
 
@@ -24,7 +24,7 @@ public func <^><T, U>(@noescape f: T -> U, a: T?) -> U? {
 
     - returns: A value of type `Optional<U>`
 */
-public func <*><T, U>(f: (T -> U)?, a: T?) -> U? {
+public func <*> <T, U>(f: (T -> U)?, a: T?) -> U? {
     return a.apply(f)
 }
 
@@ -39,7 +39,7 @@ public func <*><T, U>(f: (T -> U)?, a: T?) -> U? {
 
     - returns: A value of type `Optional<U>`
 */
-public func >>-<T, U>(a: T?, @noescape f: T -> U?) -> U? {
+public func >>- <T, U>(a: T?, @noescape f: T -> U?) -> U? {
     return a.flatMap(f)
 }
 
@@ -54,7 +54,7 @@ public func >>-<T, U>(a: T?, @noescape f: T -> U?) -> U? {
 
     - returns: A value of type `Optional<U>`
 */
-public func -<<<T, U>(@noescape f: T -> U?, a: T?) -> U? {
+public func -<< <T, U>(@noescape f: T -> U?, a: T?) -> U? {
   return a.flatMap(f)
 }
 


### PR DESCRIPTION
Adding a space after operator names in operator definitions makes it all a little easier to read.
