### PR TITLE
Mark closures `@noescape`

### DIFF
--- a/Source/Array.swift
+++ b/Source/Array.swift
@@ -36,7 +36,7 @@ public func <*><T, U>(fs: [T -> U], a: [T]) -> [U] {
 
     :returns: A value of type [U]
 */
-public func >>-<T, U>(a: [T], f: T -> [U]) -> [U] {
+public func >>-<T, U>(a: [T], @noescape f: T -> [U]) -> [U] {
     return a.flatMap(f)
 }
 
@@ -50,7 +50,7 @@ apply a function to each value of an array and flatten the resulting array
 
 :returns: A value of type [U]
 */
-public func -<<<T, U>(f: T -> [U], a: [T]) -> [U] {
+public func -<<<T, U>(@noescape f: T -> [U], a: [T]) -> [U] {
   return a.flatMap(f)
 }
 

--- a/Source/Optional.swift
+++ b/Source/Optional.swift
@@ -9,7 +9,7 @@
 
     :returns: A value of type Optional<U>
 */
-public func <^><T, U>(f: T -> U, a: T?) -> U? {
+public func <^><T, U>(@noescape f: T -> U, a: T?) -> U? {
     return a.map(f)
 }
 
@@ -39,7 +39,7 @@ public func <*><T, U>(f: (T -> U)?, a: T?) -> U? {
 
     :returns: A value of type Optional<U>
 */
-public func >>-<T, U>(a: T?, f: T -> U?) -> U? {
+public func >>-<T, U>(a: T?, @noescape f: T -> U?) -> U? {
     return a.flatMap(f)
 }
 
@@ -54,7 +54,7 @@ flatMap a function over an optional value (right associative)
 
 :returns: A value of type Optional<U>
 */
-public func -<<<T, U>(f: T -> U?, a: T?) -> U? {
+public func -<<<T, U>(@noescape f: T -> U?, a: T?) -> U? {
   return a.flatMap(f)
 }
 


### PR DESCRIPTION
I wanted to mark all closures `@noescape`, but ...
- `@noescape` cannot be applied to parameters of type array of functions nor optional function
- `Array.map`'s closure parameter isn't marked `@noescape` (`Array.flatMap`'s is though)
