### PR TITLE
Allow Runes to be used as a framework dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,19 @@ Indecipherable symbols that some people claim have actual meaning.
 
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 
-## Installation ##
+## Source Compatibility ##
 
 The source on `master` assumes Swift 2.0, and will be released as Runes 3.0.
 If you need Swift 1.2 support, please use the 2.X series of releases.
+
+## Framework Installation ##
 
 ### [Carthage] ###
 
 [Carthage]: https://github.com/Carthage/Carthage
 
 ```
-github "thoughtbot/runes"
+github "thoughtbot/Runes"
 ```
 
 Then run `carthage update`.
@@ -41,6 +43,67 @@ use_frameworks!
 ```
 
 Then run `pod install` with CocoaPods 0.36 or newer.
+
+## Adding Runes as a Framework Dependency ##
+
+If you're a framework author, you might define your own custom types that
+would benefit from the operators defined in Runes. However, adding the entire
+Runes framework as a dependency might be too much overhead. In this case, you
+can use Carthage, CocoaPods, or Git to link to the file that defines the
+operators directly into your project. This will let you use Runes as a
+centralized dependency for the definition of the operators without needing to
+worry about additional overhead for your users.
+
+By using Runes as a dependency in this way, it will be easier to ensure
+compatibility between your operator definitions and other types. This will
+also reduce the amount of duplication of effort across projects that want to
+include the same kinds of functionality.
+
+In order to use Runes as a framework dependency, you must use git submodules.
+This will allow Carthage and CocoaPods to pull down the Runes source code
+without needing to expose the dependency to your users.
+
+### [Carthage] ###
+
+Add the following to `Cartfile.private`:
+
+```
+github "thoughtbot/Runes"
+```
+
+Then run `carthage update --no-use-binaries --use-submodules`. This will
+ensure that you don't get any pre-built binaries that we are providing for
+users who want the full `Runes.framework`, and will tell Carthage to set up a
+git submodule for you.
+
+Once you've checked out the required version, you can link
+`Carthage/Checkouts/Runes/Source/Runes.swift` directly into your framework.
+
+### [CocoaPods] ###
+
+After adding Runes as a git submodule, you will need to modify your podspec to
+tell CocoaPods to pull down your submodule dependencies. This is done by
+passing a `submodules: true` flag inside your spec's `source` property.
+
+For example, the `source` for [Argo]'s main spec would look like this:
+
+```ruby
+spec.source = {
+  git: "https://github.com/thoughtbot/Argo.git",
+  tag: "v#{s.version}",
+  submodules: true # add this line
+}
+```
+
+Then add `Runes.swift` to your spec's `source_files` property. This tells
+CocoaPods to include that file when building your framework.
+
+Again, using Argo as an example, we can make our `source_files` property look
+like so:
+
+```ruby
+spec.source_files = 'Argo/**/*.{h,swift}', 'Carthage/Checkouts/Runes/Source/Runes.swift'
+```
 
 ## What's included? ##
 

--- a/Runes.xcodeproj/project.pbxproj
+++ b/Runes.xcodeproj/project.pbxproj
@@ -14,7 +14,7 @@
 		EAA6A51A1B2F163B0058E9A8 /* Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = F802D4F01A5F23BE005E236C /* Optional.swift */; };
 		EAA6A51B1B2F163F0058E9A8 /* Runes.h in Headers */ = {isa = PBXBuildFile; fileRef = F802D4D71A5F218E005E236C /* Runes.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F802D4D81A5F218E005E236C /* Runes.h in Headers */ = {isa = PBXBuildFile; fileRef = F802D4D71A5F218E005E236C /* Runes.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F802D4EF1A5F2341005E236C /* Operators.swift in Sources */ = {isa = PBXBuildFile; fileRef = F802D4EE1A5F2341005E236C /* Operators.swift */; };
+		F802D4EF1A5F2341005E236C /* Runes.swift in Sources */ = {isa = PBXBuildFile; fileRef = F802D4EE1A5F2341005E236C /* Runes.swift */; };
 		F802D4F11A5F23BE005E236C /* Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = F802D4F01A5F23BE005E236C /* Optional.swift */; };
 		F8624C2C1A645A9600C883B3 /* Runes.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F802D4D21A5F218E005E236C /* Runes.framework */; };
 		F8624C381A645B0700C883B3 /* OptionalSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8624C371A645B0700C883B3 /* OptionalSpec.swift */; };
@@ -29,7 +29,7 @@
 		F8624C601A647EE400C883B3 /* ArraySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8624C5F1A647EE400C883B3 /* ArraySpec.swift */; };
 		F8624C611A647FB300C883B3 /* ArraySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8624C5F1A647EE400C883B3 /* ArraySpec.swift */; };
 		F86B2E241A5F2B9E00C3B8BD /* Runes.h in Headers */ = {isa = PBXBuildFile; fileRef = F802D4D71A5F218E005E236C /* Runes.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F86B2E251A5F2BA400C3B8BD /* Operators.swift in Sources */ = {isa = PBXBuildFile; fileRef = F802D4EE1A5F2341005E236C /* Operators.swift */; };
+		F86B2E251A5F2BA400C3B8BD /* Runes.swift in Sources */ = {isa = PBXBuildFile; fileRef = F802D4EE1A5F2341005E236C /* Runes.swift */; };
 		F86B2E261A5F2BA400C3B8BD /* Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = F802D4F01A5F23BE005E236C /* Optional.swift */; };
 		F8AAD42E1A656EF800271271 /* Fox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8AAD42D1A656EF800271271 /* Fox.framework */; };
 		F8AAD4301A656F0000271271 /* Fox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8AAD42F1A656F0000271271 /* Fox.framework */; };
@@ -97,7 +97,7 @@
 		F802D4D21A5F218E005E236C /* Runes.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Runes.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F802D4D61A5F218E005E236C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		F802D4D71A5F218E005E236C /* Runes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Runes.h; sourceTree = "<group>"; };
-		F802D4EE1A5F2341005E236C /* Operators.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Operators.swift; sourceTree = "<group>"; };
+		F802D4EE1A5F2341005E236C /* Runes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Runes.swift; sourceTree = "<group>"; };
 		F802D4F01A5F23BE005E236C /* Optional.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Optional.swift; sourceTree = "<group>"; };
 		F8624C261A645A9600C883B3 /* Runes-iOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Runes-iOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8624C341A645AB900C883B3 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -190,7 +190,7 @@
 			isa = PBXGroup;
 			children = (
 				4A8C7DE71A5F58330050914C /* Array.swift */,
-				F802D4EE1A5F2341005E236C /* Operators.swift */,
+				F802D4EE1A5F2341005E236C /* Runes.swift */,
 				F802D4F01A5F23BE005E236C /* Optional.swift */,
 				F802D4D51A5F218E005E236C /* Supporting Files */,
 			);
@@ -496,7 +496,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F802D4EF1A5F2341005E236C /* Operators.swift in Sources */,
+				F802D4EF1A5F2341005E236C /* Runes.swift in Sources */,
 				F802D4F11A5F23BE005E236C /* Optional.swift in Sources */,
 				4A8C7DE81A5F58330050914C /* Array.swift in Sources */,
 			);
@@ -526,7 +526,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F86B2E251A5F2BA400C3B8BD /* Operators.swift in Sources */,
+				F86B2E251A5F2BA400C3B8BD /* Runes.swift in Sources */,
 				F86B2E261A5F2BA400C3B8BD /* Optional.swift in Sources */,
 				4A8C7DE91A5F58330050914C /* Array.swift in Sources */,
 			);

--- a/Source/Operators.swift
+++ b/Source/Operators.swift
@@ -1,4 +1,0 @@
-infix operator <^> { associativity left precedence 130 }
-infix operator <*> { associativity left precedence 130 }
-infix operator >>- { associativity left precedence 100 }
-infix operator -<< { associativity right precedence 100 }

--- a/Source/Runes.swift
+++ b/Source/Runes.swift
@@ -1,0 +1,52 @@
+/**
+map a function over a value with context
+
+Expected function type: `(a -> b) -> f a -> f b`
+
+*/
+infix operator <^> {
+    associativity left
+
+    // Same precedence as the equality operator (`==`)
+    precedence 130
+}
+
+/**
+apply a function with context to a value with context
+
+Expected function type: `f (a -> b) -> f a -> f b`
+*/
+infix operator <*> {
+    associativity left
+
+    // Same precedence as the equality operator (`==`)
+    precedence 130
+}
+
+/**
+map a function over a value with context and flatten the result
+
+Expected function type: `m a -> (a -> m b) -> m b`
+*/
+infix operator >>- {
+    associativity left
+
+    // Lower precedence than the logical comparison operators
+    // (`&&` and `||`), but higher precedence than the assignment
+    // operator (`=`)
+    precedence 100
+}
+
+/**
+map a function over a value with context and flatten the result
+
+Expected function type: `(a -> m b) -> m a -> m b`
+*/
+infix operator -<< {
+    associativity right
+
+    // Lower precedence than the logical comparison operators
+    // (`&&` and `||`), but higher precedence than the assignment
+    // operator (`=`)
+    precedence 100
+}


### PR DESCRIPTION
This comes out of discussion in antitypical/Result#54. The end goal is
to be able to use the operator definitions in Runes _without_ needing to
include the entire Runes.framework as a dependency. This will allow 3rd
party frameworks to stay light-weight while centralizing the operator
definitions for the sake of consistency.
