### PR TITLE
Don't make Array's flatmap functions noescape

### DIFF
--- a/Source/Array.swift
+++ b/Source/Array.swift
@@ -36,7 +36,7 @@ public func <*> <T, U>(fs: [T -> U], a: [T]) -> [U] {
 
     - returns: A value of type `[U]`
 */
-public func >>- <T, U>(a: [T], @noescape f: T -> [U]) -> [U] {
+public func >>- <T, U>(a: [T], f: T -> [U]) -> [U] {
     return a.flatMap(f)
 }
 
@@ -50,7 +50,7 @@ public func >>- <T, U>(a: [T], @noescape f: T -> [U]) -> [U] {
 
     - returns: A value of type `[U]`
 */
-public func -<< <T, U>(@noescape f: T -> [U], a: [T]) -> [U] {
+public func -<< <T, U>(f: T -> [U], a: [T]) -> [U] {
   return a.flatMap(f)
 }
 


### PR DESCRIPTION
This is insane, but Swift added a version of `flatMap` to the stdlib for
Array with this function signature:

``` swift
extension SequenceType {
  func flatMap<T>(@noescape transform: (Self.Generator.Element) -> T?) -> [T]
}
```

_Clearly_ that isn't `flatMap`, and is instead `catOptionals . map`, but
there's nothing I can do about that.

Annoyingly, this broke Runes because the function passed to that version
of `flatMap` is marked as `@noescape`, while the other isn't (even
though it _is_ `@noescape` in reality).

The result of this is that since we were marking the function passed to
our `flatMap` operator as `@noescape`, it decided to use
not-actually-`flatMap` instead of the real thing.

The fix for this is to not mark our function as `@noescape` (even though
it is), which convinces the compiler to use the real version of
`flatMap` instead of that other thing that shouldn't actually exist in
the first place.

Fixes #44
