### PR TITLE
Move from Fox to SwiftCheck

### DIFF
--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,1 +1,1 @@
-github "typelift/SwiftCheck" "master"
+github "typelift/SwiftCheck" ~> 0.3.1

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,3 +1,1 @@
-github "Quick/Quick" ~> 0.5.0
-github "jeffh/Fox" "master"
-github "thoughtbot/NimbleFox" ~> 2.0.0
+github "typelift/SwiftCheck" "master"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "typelift/SwiftCheck" "f8a75ef8c47d39079c0618c03c66fddd0a0e78f2"
+github "typelift/SwiftCheck" "v0.3.1"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,1 @@
-github "jeffh/Fox" "78cc9dc1d446a1005cfb8a39a3e7c859f0608227"
-github "gfontenot/Nimble" "dbc5bb3e2bd7e7ce322b128d674983937bbffd57"
-github "Quick/Quick" "v0.5.0"
-github "thoughtbot/NimbleFox" "v2.0.0"
+github "typelift/SwiftCheck" "f8a75ef8c47d39079c0618c03c66fddd0a0e78f2"

--- a/Runes.xcodeproj/project.pbxproj
+++ b/Runes.xcodeproj/project.pbxproj
@@ -10,7 +10,7 @@
 		4A8C7DE81A5F58330050914C /* Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A8C7DE71A5F58330050914C /* Array.swift */; };
 		4A8C7DE91A5F58330050914C /* Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A8C7DE71A5F58330050914C /* Array.swift */; };
 		EAA6A5181B2F163B0058E9A8 /* Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A8C7DE71A5F58330050914C /* Array.swift */; };
-		EAA6A5191B2F163B0058E9A8 /* Operators.swift in Sources */ = {isa = PBXBuildFile; fileRef = F802D4EE1A5F2341005E236C /* Operators.swift */; };
+		EAA6A5191B2F163B0058E9A8 /* Runes.swift in Sources */ = {isa = PBXBuildFile; fileRef = F802D4EE1A5F2341005E236C /* Runes.swift */; };
 		EAA6A51A1B2F163B0058E9A8 /* Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = F802D4F01A5F23BE005E236C /* Optional.swift */; };
 		EAA6A51B1B2F163F0058E9A8 /* Runes.h in Headers */ = {isa = PBXBuildFile; fileRef = F802D4D71A5F218E005E236C /* Runes.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F802D4D81A5F218E005E236C /* Runes.h in Headers */ = {isa = PBXBuildFile; fileRef = F802D4D71A5F218E005E236C /* Runes.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -18,12 +18,8 @@
 		F802D4F11A5F23BE005E236C /* Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = F802D4F01A5F23BE005E236C /* Optional.swift */; };
 		F8624C2C1A645A9600C883B3 /* Runes.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F802D4D21A5F218E005E236C /* Runes.framework */; };
 		F8624C381A645B0700C883B3 /* OptionalSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8624C371A645B0700C883B3 /* OptionalSpec.swift */; };
-		F8624C3D1A645B2C00C883B3 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8624C3B1A645B2C00C883B3 /* Quick.framework */; };
-		F8624C401A645C1A00C883B3 /* Quick.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = F8624C3B1A645B2C00C883B3 /* Quick.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F8624C4B1A645C9500C883B3 /* Runes.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F86B2E0B1A5F2B8D00C3B8BD /* Runes.framework */; };
 		F8624C511A645CB900C883B3 /* OptionalSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8624C371A645B0700C883B3 /* OptionalSpec.swift */; };
-		F8624C571A645D0300C883B3 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8624C551A645D0300C883B3 /* Quick.framework */; };
-		F8624C5A1A645D1400C883B3 /* Quick.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = F8624C551A645D0300C883B3 /* Quick.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F8624C5D1A647E6F00C883B3 /* Functions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8624C5C1A647E6F00C883B3 /* Functions.swift */; };
 		F8624C5E1A647E7300C883B3 /* Functions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8624C5C1A647E6F00C883B3 /* Functions.swift */; };
 		F8624C601A647EE400C883B3 /* ArraySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8624C5F1A647EE400C883B3 /* ArraySpec.swift */; };
@@ -31,18 +27,10 @@
 		F86B2E241A5F2B9E00C3B8BD /* Runes.h in Headers */ = {isa = PBXBuildFile; fileRef = F802D4D71A5F218E005E236C /* Runes.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F86B2E251A5F2BA400C3B8BD /* Runes.swift in Sources */ = {isa = PBXBuildFile; fileRef = F802D4EE1A5F2341005E236C /* Runes.swift */; };
 		F86B2E261A5F2BA400C3B8BD /* Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = F802D4F01A5F23BE005E236C /* Optional.swift */; };
-		F8AAD42E1A656EF800271271 /* Fox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8AAD42D1A656EF800271271 /* Fox.framework */; };
-		F8AAD4301A656F0000271271 /* Fox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8AAD42F1A656F0000271271 /* Fox.framework */; };
-		F8AAD4311A656F1A00271271 /* Fox.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = F8AAD42F1A656F0000271271 /* Fox.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		F8AAD4321A656F1D00271271 /* Fox.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = F8AAD42D1A656EF800271271 /* Fox.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		F8E59DA61A71824C00F67771 /* Nimble.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = F8E59DA21A71821F00F67771 /* Nimble.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		F8E59DA71A71824C00F67771 /* NimbleFox.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = F8E59DA31A71821F00F67771 /* NimbleFox.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		F8E59DA81A71825300F67771 /* Nimble.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = F8E59DA01A71821000F67771 /* Nimble.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		F8E59DA91A71825300F67771 /* NimbleFox.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = F8E59DA11A71821000F67771 /* NimbleFox.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		F8E59DAA1A71825600F67771 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8E59DA01A71821000F67771 /* Nimble.framework */; };
-		F8E59DAB1A71825600F67771 /* NimbleFox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8E59DA11A71821000F67771 /* NimbleFox.framework */; };
-		F8E59DAC1A71825C00F67771 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8E59DA21A71821F00F67771 /* Nimble.framework */; };
-		F8E59DAD1A71825C00F67771 /* NimbleFox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8E59DA31A71821F00F67771 /* NimbleFox.framework */; };
+		F88DE9731BA3854E00A9D383 /* SwiftCheck.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F88DE9721BA3854E00A9D383 /* SwiftCheck.framework */; settings = {ASSET_TAGS = (); }; };
+		F88DE9751BA3855600A9D383 /* SwiftCheck.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F88DE9741BA3855600A9D383 /* SwiftCheck.framework */; settings = {ASSET_TAGS = (); }; };
+		F89776E51BA601D500EE823E /* SwiftCheck.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = F88DE9741BA3855600A9D383 /* SwiftCheck.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		F89776E61BA601DE00EE823E /* SwiftCheck.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = F88DE9721BA3854E00A9D383 /* SwiftCheck.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -69,10 +57,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				F8624C401A645C1A00C883B3 /* Quick.framework in CopyFiles */,
-				F8AAD4321A656F1D00271271 /* Fox.framework in CopyFiles */,
-				F8E59DA61A71824C00F67771 /* Nimble.framework in CopyFiles */,
-				F8E59DA71A71824C00F67771 /* NimbleFox.framework in CopyFiles */,
+				F89776E61BA601DE00EE823E /* SwiftCheck.framework in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -82,10 +67,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				F8624C5A1A645D1400C883B3 /* Quick.framework in CopyFiles */,
-				F8AAD4311A656F1A00271271 /* Fox.framework in CopyFiles */,
-				F8E59DA81A71825300F67771 /* Nimble.framework in CopyFiles */,
-				F8E59DA91A71825300F67771 /* NimbleFox.framework in CopyFiles */,
+				F89776E51BA601D500EE823E /* SwiftCheck.framework in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -102,18 +84,12 @@
 		F8624C261A645A9600C883B3 /* Runes-iOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Runes-iOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8624C341A645AB900C883B3 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		F8624C371A645B0700C883B3 /* OptionalSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OptionalSpec.swift; sourceTree = "<group>"; };
-		F8624C3B1A645B2C00C883B3 /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/iOS/Quick.framework; sourceTree = SOURCE_ROOT; };
 		F8624C451A645C9500C883B3 /* Runes-Mac Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Runes-Mac Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
-		F8624C551A645D0300C883B3 /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/Mac/Quick.framework; sourceTree = SOURCE_ROOT; };
 		F8624C5C1A647E6F00C883B3 /* Functions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Functions.swift; sourceTree = "<group>"; };
 		F8624C5F1A647EE400C883B3 /* ArraySpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArraySpec.swift; sourceTree = "<group>"; };
 		F86B2E0B1A5F2B8D00C3B8BD /* Runes.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Runes.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		F8AAD42D1A656EF800271271 /* Fox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Fox.framework; path = Carthage/Build/iOS/Fox.framework; sourceTree = SOURCE_ROOT; };
-		F8AAD42F1A656F0000271271 /* Fox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Fox.framework; path = Carthage/Build/Mac/Fox.framework; sourceTree = SOURCE_ROOT; };
-		F8E59DA01A71821000F67771 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/Mac/Nimble.framework; sourceTree = SOURCE_ROOT; };
-		F8E59DA11A71821000F67771 /* NimbleFox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = NimbleFox.framework; path = Carthage/Build/Mac/NimbleFox.framework; sourceTree = SOURCE_ROOT; };
-		F8E59DA21A71821F00F67771 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/iOS/Nimble.framework; sourceTree = SOURCE_ROOT; };
-		F8E59DA31A71821F00F67771 /* NimbleFox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = NimbleFox.framework; path = Carthage/Build/iOS/NimbleFox.framework; sourceTree = SOURCE_ROOT; };
+		F88DE9721BA3854E00A9D383 /* SwiftCheck.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftCheck.framework; path = Carthage/Build/iOS/SwiftCheck.framework; sourceTree = SOURCE_ROOT; };
+		F88DE9741BA3855600A9D383 /* SwiftCheck.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftCheck.framework; path = Carthage/Build/Mac/SwiftCheck.framework; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -136,10 +112,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F8624C2C1A645A9600C883B3 /* Runes.framework in Frameworks */,
-				F8AAD42E1A656EF800271271 /* Fox.framework in Frameworks */,
-				F8624C3D1A645B2C00C883B3 /* Quick.framework in Frameworks */,
-				F8E59DAC1A71825C00F67771 /* Nimble.framework in Frameworks */,
-				F8E59DAD1A71825C00F67771 /* NimbleFox.framework in Frameworks */,
+				F88DE9731BA3854E00A9D383 /* SwiftCheck.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -148,10 +121,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F8624C4B1A645C9500C883B3 /* Runes.framework in Frameworks */,
-				F8AAD4301A656F0000271271 /* Fox.framework in Frameworks */,
-				F8624C571A645D0300C883B3 /* Quick.framework in Frameworks */,
-				F8E59DAA1A71825600F67771 /* Nimble.framework in Frameworks */,
-				F8E59DAB1A71825600F67771 /* NimbleFox.framework in Frameworks */,
+				F88DE9751BA3855600A9D383 /* SwiftCheck.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -246,10 +216,7 @@
 		F8624C521A645CE200C883B3 /* iOS */ = {
 			isa = PBXGroup;
 			children = (
-				F8E59DA21A71821F00F67771 /* Nimble.framework */,
-				F8E59DA31A71821F00F67771 /* NimbleFox.framework */,
-				F8AAD42D1A656EF800271271 /* Fox.framework */,
-				F8624C3B1A645B2C00C883B3 /* Quick.framework */,
+				F88DE9721BA3854E00A9D383 /* SwiftCheck.framework */,
 			);
 			name = iOS;
 			sourceTree = "<group>";
@@ -257,10 +224,7 @@
 		F8624C531A645CF400C883B3 /* OS X */ = {
 			isa = PBXGroup;
 			children = (
-				F8E59DA01A71821000F67771 /* Nimble.framework */,
-				F8E59DA11A71821000F67771 /* NimbleFox.framework */,
-				F8AAD42F1A656F0000271271 /* Fox.framework */,
-				F8624C551A645D0300C883B3 /* Quick.framework */,
+				F88DE9741BA3855600A9D383 /* SwiftCheck.framework */,
 			);
 			name = "OS X";
 			sourceTree = "<group>";
@@ -487,7 +451,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				EAA6A5181B2F163B0058E9A8 /* Array.swift in Sources */,
-				EAA6A5191B2F163B0058E9A8 /* Operators.swift in Sources */,
+				EAA6A5191B2F163B0058E9A8 /* Runes.swift in Sources */,
 				EAA6A51A1B2F163B0058E9A8 /* Optional.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -854,6 +818,7 @@
 				EAA6A5161B2F154D0058E9A8 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		F802D4CC1A5F218E005E236C /* Build configuration list for PBXProject "Runes" */ = {
 			isa = XCConfigurationList;

--- a/Tests/Helpers/Functions.swift
+++ b/Tests/Helpers/Functions.swift
@@ -1,5 +1,3 @@
-import Fox
-
 func id<A>(a: A) -> A {
     return a
 }
@@ -18,10 +16,4 @@ func append(x: String) -> String {
 
 func prepend(x: String) -> String {
     return "baz" + x
-}
-
-func generateString(block:String -> Bool) -> FOXGenerator {
-    return forAll(string()) { string in
-        return block(string as! String)
-    }
 }

--- a/Tests/Helpers/Functions.swift
+++ b/Tests/Helpers/Functions.swift
@@ -9,11 +9,3 @@ func compose<A, B, C>(fa: A -> B, _ fb: B -> C) -> A -> C {
 func curry<A, B, C>(f: (A, B) -> C) -> A -> B -> C {
     return { a in { b in f(a, b) }}
 }
-
-func append(x: String) -> String {
-    return x + "bar"
-}
-
-func prepend(x: String) -> String {
-    return "baz" + x
-}

--- a/Tests/Tests/ArraySpec.swift
+++ b/Tests/Tests/ArraySpec.swift
@@ -1,6 +1,4 @@
-import func SwiftCheck.property
-import func SwiftCheck.forAll
-import func SwiftCheck.<-
+import SwiftCheck
 import XCTest
 import Runes
 

--- a/Tests/Tests/ArraySpec.swift
+++ b/Tests/Tests/ArraySpec.swift
@@ -5,7 +5,7 @@ import Runes
 class ArraySpec: XCTestCase {
     func testFunctor() {
         // fmap id = id
-        property("identity law") <- forAll { (xs: [String]) in
+        property("identity law") <- forAll { (xs: [Int]) in
             let lhs = id <^> xs
             let rhs = xs
 
@@ -13,7 +13,7 @@ class ArraySpec: XCTestCase {
         }
 
         // fmap (f . g) = (fmap f) . (fmap g)
-        property("function composition law") <- forAll { (a: ArrayOf<String>, fa: ArrowOf<String, String>, fb: ArrowOf<String, String>) in
+        property("function composition law") <- forAll { (a: ArrayOf<Int>, fa: ArrowOf<Int, Int>, fb: ArrowOf<Int, Int>) in
             let xs = a.getArray
             let f = fa.getArrow
             let g = fb.getArrow
@@ -27,7 +27,7 @@ class ArraySpec: XCTestCase {
 
     func testApplicative() {
         // pure id <*> x = x
-        property("identity law") <- forAll { (xs: [String]) in
+        property("identity law") <- forAll { (xs: [Int]) in
             let lhs = pure(id) <*> xs
             let rhs = xs
 
@@ -35,17 +35,17 @@ class ArraySpec: XCTestCase {
         }
 
         // pure f <*> pure x = pure (f x)
-        property("homomorphism law") <- forAll { (x: String, fa: ArrowOf<String, String>) in
+        property("homomorphism law") <- forAll { (x: Int, fa: ArrowOf<Int, Int>) in
             let f = fa.getArrow
 
-            let lhs: [String] = pure(f) <*> pure(x)
-            let rhs: [String] = pure(f(x))
+            let lhs: [Int] = pure(f) <*> pure(x)
+            let rhs: [Int] = pure(f(x))
 
             return rhs == lhs
         }
 
         // f <*> pure x = pure ($ x) <*> f
-        property("interchange law") <- forAll { (x: String, fa: ArrayOf<ArrowOf<String, String>>) in
+        property("interchange law") <- forAll { (x: Int, fa: ArrayOf<ArrowOf<Int, Int>>) in
             let f = fa.getArray.map { $0.getArrow }
 
             let lhs = f <*> pure(x)
@@ -55,7 +55,7 @@ class ArraySpec: XCTestCase {
         }
 
         // f <*> (g <*> x) = pure (.) <*> f <*> g <*> x
-        property("composition law") <- forAll { (a: ArrayOf<String>, fa: ArrayOf<ArrowOf<String, String>>, fb: ArrayOf<ArrowOf<String, String>>) in
+        property("composition law") <- forAll { (a: ArrayOf<Int>, fa: ArrayOf<ArrowOf<Int, Int>>, fb: ArrayOf<ArrowOf<Int, Int>>) in
             let x = a.getArray
             let f = fa.getArray.map { $0.getArrow }
             let g = fb.getArray.map { $0.getArrow }
@@ -69,8 +69,8 @@ class ArraySpec: XCTestCase {
 
     func testMonad() {
         // return x >>= f = f x
-        property("left identity law") <- forAll { (x: String, fa: ArrowOf<String, String>) in
-            let f: String -> [String] = compose(fa.getArrow, pure)
+        property("left identity law") <- forAll { (x: Int, fa: ArrowOf<Int, Int>) in
+            let f: Int -> [Int] = compose(fa.getArrow, pure)
 
             let lhs = pure(x) >>- f
             let rhs = f(x)
@@ -79,7 +79,7 @@ class ArraySpec: XCTestCase {
         }
 
         // m >>= return = m
-        property("right identity law") <- forAll { (x: [String]) in
+        property("right identity law") <- forAll { (x: [Int]) in
             let lhs = x >>- pure
             let rhs = x
 
@@ -87,10 +87,10 @@ class ArraySpec: XCTestCase {
         }
 
         // (m >>= f) >>= g = m >>= (\x -> f x >>= g)
-        property("associativity law") <- forAll { (a: ArrayOf<String>, fa: ArrowOf<String, String>, fb: ArrowOf<String, String>) in
+        property("associativity law") <- forAll { (a: ArrayOf<Int>, fa: ArrowOf<Int, Int>, fb: ArrowOf<Int, Int>) in
             let m = a.getArray
-            let f: String -> [String] = compose(fa.getArrow, pure)
-            let g: String -> [String] = compose(fb.getArrow, pure)
+            let f: Int -> [Int] = compose(fa.getArrow, pure)
+            let g: Int -> [Int] = compose(fb.getArrow, pure)
 
             let lhs = (m >>- f) >>- g
             let rhs = m >>- { x in f(x) >>- g }

--- a/Tests/Tests/ArraySpec.swift
+++ b/Tests/Tests/ArraySpec.swift
@@ -1,131 +1,85 @@
-import Fox
-import Nimble
-import NimbleFox
-import Quick
+import func SwiftCheck.property
+import func SwiftCheck.forAll
+import func SwiftCheck.<-
+import XCTest
 import Runes
 
-private func generateArray(block:[String] -> Bool) -> FOXGenerator {
-    return forAll(array(string())) { array in
-        return block(array as! [String])
+class ArraySpec: XCTestCase {
+    func testFunctor() {
+        // fmap id = id
+        property("identity law") <- forAll { (array: [String]) in
+            let lhs = id <^> array
+            let rhs = array
+
+            return lhs == rhs
+        }
+
+        // fmap (g . h) = (fmap g) . (fmap h)
+        property("function composition law") <- forAll { (array: [String]) in
+            let lhs = compose(append, prepend) <^> array
+            let rhs = compose(curry(<^>)(append), curry(<^>)(prepend))(array)
+
+            return lhs == rhs
+        }
     }
-}
 
-class ArraySpec: QuickSpec {
-    override func spec() {
-        describe("Array") {
-            describe("map") {
-                // fmap id = id
-                it("obeys the identity law") {
-                    let property = generateArray() { array in
-                        let lhs = id <^> array
-                        let rhs = array
+    func testApplicative() {
+        // pure id <*> v = v
+        property("identity law") <- forAll { (array: [String]) in
+            let lhs = pure(id) <*> array
+            let rhs = array
 
-                        return lhs == rhs
-                    }
+            return lhs == rhs
+        }
 
-                    expect(property).to(hold())
-                }
+        // pure f <*> pure x = pure (f x)
+        property("homomorphism law") <- forAll { (string: String) in
+            let lhs: [String] = pure(append) <*> pure(string)
+            let rhs: [String] = pure(append(string))
 
-                // fmap (g . h) = (fmap g) . (fmap h)
-                it("obeys the function composition law") {
-                    let property = generateArray() { array in
-                        let lhs = compose(append, prepend) <^> array
-                        let rhs = compose(curry(<^>)(append), curry(<^>)(prepend))(array)
+            return rhs == lhs
+        }
 
-                        return lhs == rhs
-                    }
+        // u <*> pure y = pure ($ y) <*> u
+        property("interchange law") <- forAll { (string: String) in
+            let lhs: [String] = pure(append) <*> pure(string)
+            let rhs: [String] = pure({ $0(string) }) <*> pure(append)
 
-                    expect(property).to(hold())
-                }
-            }
+            return lhs == rhs
+        }
 
-            describe("apply") {
-                // pure id <*> v = v
-                it("obeys the identity law") {
-                    let property = generateArray() { array in
-                        let lhs = pure(id) <*> array
-                        let rhs = array
+        // u <*> (v <*> w) = pure (.) <*> u <*> v <*> w
+        property("composition law") <- forAll { (array: [String]) in
+            let lhs = pure(append) <*> (pure(prepend) <*> array)
+            let rhs = pure(curry(compose)) <*> pure(append)  <*> pure(prepend) <*> array
 
-                        return lhs == rhs
-                    }
+            return lhs == rhs
+        }
+    }
 
-                    expect(property).to(hold())
-                }
+    func testMonad() {
+        // return x >>= f = f x
+        property("left identity law") <- forAll { (string: String) in
+            let lhs: [String] = pure(string) >>- compose(append, pure)
+            let rhs: [String] = compose(append, pure)(string)
 
-                // pure f <*> pure x = pure (f x)
-                it("obeys the homomorphism law") {
-                    let property = generateString() { string in
-                        let lhs: [String] = pure(append) <*> pure(string)
-                        let rhs: [String] = pure(append(string))
+            return lhs == rhs
+        }
 
-                        return rhs == lhs
-                    }
+        // m >>= return = m
+        property("right identity law") <- forAll { (array: [String]) in
+            let lhs = array >>- pure
+            let rhs = array
 
-                    expect(property).to(hold())
-                }
+            return lhs == rhs
+        }
 
-                // u <*> pure y = pure ($ y) <*> u
-                it("obeys the interchange law") {
-                    let property = generateString() { string in
-                        let lhs: [String] = pure(append) <*> pure(string)
-                        let rhs: [String] = pure({ $0(string) }) <*> pure(append)
+        // (m >>= f) >>= g = m >>= (\x -> f x >>= g)
+        property("associativity law") <- forAll { (array: [String]) in
+            let lhs = (array >>- compose(append, pure)) >>- compose(prepend, pure)
+            let rhs = array >>- { x in compose(append, pure)(x) >>- compose(prepend, pure) }
 
-                        return lhs == rhs
-                    }
-
-                    expect(property).to(hold())
-                }
-
-                // u <*> (v <*> w) = pure (.) <*> u <*> v <*> w
-                it("obeys the composition law") {
-                    let property = generateArray() { array in
-                        let lhs = pure(append) <*> (pure(prepend) <*> array)
-                        let rhs = pure(curry(compose)) <*> pure(append)  <*> pure(prepend) <*> array
-
-                        return lhs == rhs
-                    }
-
-                    expect(property).to(hold())
-                }
-            }
-
-            describe("flatMap") {
-                // return x >>= f = f x
-                it("obeys the left identity law") {
-                    let property = generateString() { string in
-                        let lhs: [String] = pure(string) >>- compose(append, pure)
-                        let rhs: [String] = compose(append, pure)(string)
-
-                        return lhs == rhs
-                    }
-
-                    expect(property).to(hold())
-                }
-
-                // m >>= return = m
-                it("obeys the right identity law") {
-                    let property = generateArray() { array in
-                        let lhs = array >>- pure
-                        let rhs = array
-
-                        return lhs == rhs
-                    }
-
-                    expect(property).to(hold())
-                }
-
-                // (m >>= f) >>= g = m >>= (\x -> f x >>= g)
-                it("obeys the associativity law") {
-                    let property = generateArray() { array in
-                        let lhs = (array >>- compose(append, pure)) >>- compose(prepend, pure)
-                        let rhs = array >>- { x in compose(append, pure)(x) >>- compose(prepend, pure) }
-
-                        return lhs == rhs
-                    }
-
-                    expect(property).to(hold())
-                }
-            }
+            return lhs == rhs
         }
     }
 }

--- a/Tests/Tests/OptionalSpec.swift
+++ b/Tests/Tests/OptionalSpec.swift
@@ -5,17 +5,21 @@ import Runes
 class OptionalSpec: XCTestCase {
     func testFunctor() {
         // fmap id = id
-        property("identity law") <- forAll { (optional: String?) in
-            let lhs = id <^> optional
-            let rhs = optional
+        property("identity law") <- forAll { (x: String?) in
+            let lhs = id <^> x
+            let rhs = x
 
             return lhs == rhs
         }
 
-        // fmap (g . h) = (fmap g) . (fmap h)
-        property("function composition law") <- forAll { (optional: String?) in
-            let lhs = compose(append, prepend) <^> optional
-            let rhs = compose(curry(<^>)(append), curry(<^>)(prepend))(optional)
+        // fmap (f . g) = (fmap f) . (fmap g)
+        property("function composition law") <- forAll { (o: OptionalOf<String>, fa: ArrowOf<String, String>, fb: ArrowOf<String, String>) in
+            let f = fa.getArrow
+            let g = fb.getArrow
+            let x = o.getOptional
+
+            let lhs = compose(f, g) <^> x
+            let rhs = compose(curry(<^>)(f), curry(<^>)(g))(x)
 
             return lhs == rhs
         }
@@ -23,33 +27,41 @@ class OptionalSpec: XCTestCase {
 
     func testApplicative() {
         // pure id <*> v = v
-        property("identity law") <- forAll { (optional: String?) in
-            let lhs = pure(id) <*> optional
-            let rhs = optional
+        property("identity law") <- forAll { (x: String?) in
+            let lhs = pure(id) <*> x
+            let rhs = x
 
             return lhs == rhs
         }
 
         // pure f <*> pure x = pure (f x)
-        property("homomorphism law") <- forAll { (string: String) in
-            let lhs: String? = pure(append) <*> pure(string)
-            let rhs: String? = pure(append(string))
+        property("homomorphism law") <- forAll { (x: String, fa: ArrowOf<String, String>) in
+            let f = fa.getArrow
+
+            let lhs: String? = pure(f) <*> pure(x)
+            let rhs: String? = pure(f(x))
 
             return rhs == lhs
         }
 
-        // u <*> pure y = pure ($ y) <*> u
-        property("interchange law") <- forAll { (string: String) in
-            let lhs: String? = pure(append) <*> pure(string)
-            let rhs: String? = pure({ $0(string) }) <*> pure(append)
+        // f <*> pure x = pure ($ x) <*> f
+        property("interchange law") <- forAll { (x: String, fa: OptionalOf<ArrowOf<String, String>>) in
+            let f = fa.getOptional?.getArrow
+
+            let lhs = f <*> pure(x)
+            let rhs = pure({ $0(x) }) <*> f
 
             return lhs == rhs
         }
 
-        // u <*> (v <*> w) = pure (.) <*> u <*> v <*> w
-        property("compospropertyion law") <- forAll { (optional: String?) in
-            let lhs = pure(append) <*> (pure(prepend) <*> optional)
-            let rhs = pure(curry(compose)) <*> pure(append)  <*> pure(prepend) <*> optional
+        // f <*> (g <*> x) = pure (.) <*> f <*> g <*> x
+        property("composition law") <- forAll { (o: OptionalOf<String>, fa: OptionalOf<ArrowOf<String, String>>, fb: OptionalOf<ArrowOf<String, String>>) in
+            let x = o.getOptional
+            let f = fa.getOptional?.getArrow
+            let g = fb.getOptional?.getArrow
+
+            let lhs = f <*> (g <*> x)
+            let rhs = pure(curry(compose)) <*> f <*> g <*> x
 
             return lhs == rhs
         }
@@ -57,25 +69,33 @@ class OptionalSpec: XCTestCase {
 
     func testMonad() {
         // return x >>= f = f x
-        property("left identity law") <- forAll { (string: String) in
-            let lhs: String? = pure(string) >>- compose(append, pure)
-            let rhs: String? = compose(append, pure)(string)
+        property("left identity law") <- forAll { (x: String, fa: ArrowOf<String, String>) in
+            let f: String -> String? = compose(fa.getArrow, pure)
+
+            let lhs = pure(x) >>- f
+            let rhs = f(x)
 
             return lhs == rhs
         }
 
         // m >>= return = m
-        property("right identity law") <- forAll { (optional: String?) in
-            let lhs = optional >>- pure
-            let rhs = optional
+        property("right identity law") <- forAll { (o: OptionalOf<String>) in
+            let x = o.getOptional
+
+            let lhs = x >>- pure
+            let rhs = x
 
             return lhs == rhs
         }
 
         // (m >>= f) >>= g = m >>= (\x -> f x >>= g)
-        property("associativity law") <- forAll { (optional: String?) in
-            let lhs = (optional >>- compose(append, pure)) >>- compose(prepend, pure)
-            let rhs = optional >>- { x in compose(append, pure)(x) >>- compose(prepend, pure) }
+        property("associativity law") <- forAll { (o: OptionalOf<String>, fa: ArrowOf<String, String>, fb: ArrowOf<String, String>) in
+            let m = o.getOptional
+            let f: String -> String? = compose(fa.getArrow, pure)
+            let g: String -> String? = compose(fb.getArrow, pure)
+
+            let lhs = (m >>- f) >>- g
+            let rhs = m >>- { x in f(x) >>- g }
 
             return lhs == rhs
         }

--- a/Tests/Tests/OptionalSpec.swift
+++ b/Tests/Tests/OptionalSpec.swift
@@ -1,131 +1,85 @@
-import Fox
-import Nimble
-import NimbleFox
-import Quick
+import func SwiftCheck.property
+import func SwiftCheck.forAll
+import func SwiftCheck.<-
+import XCTest
 import Runes
 
-private func generateOptional(block: String? -> Bool) -> FOXGenerator {
-    return forAll(FOXOptional(string())) { optional in
-        return block(optional as! String?)
+class OptionalSpec: XCTestCase {
+    func testFunctor() {
+        // fmap id = id
+        property("identity law") <- forAll { (optional: String?) in
+            let lhs = id <^> optional
+            let rhs = optional
+
+            return lhs == rhs
+        }
+
+        // fmap (g . h) = (fmap g) . (fmap h)
+        property("function composition law") <- forAll { (optional: String?) in
+            let lhs = compose(append, prepend) <^> optional
+            let rhs = compose(curry(<^>)(append), curry(<^>)(prepend))(optional)
+
+            return lhs == rhs
+        }
     }
-}
 
-class OptionalSpec: QuickSpec {
-    override func spec() {
-        describe("Optional") {
-            describe("map") {
-                // fmap id = id
-                it("obeys the identity law") {
-                    let property = generateOptional() { optional in
-                        let lhs = id <^> optional
-                        let rhs = optional
+    func testApplicative() {
+        // pure id <*> v = v
+        property("identity law") <- forAll { (optional: String?) in
+            let lhs = pure(id) <*> optional
+            let rhs = optional
 
-                        return lhs == rhs
-                    }
+            return lhs == rhs
+        }
 
-                    expect(property).to(hold())
-                }
+        // pure f <*> pure x = pure (f x)
+        property("homomorphism law") <- forAll { (string: String) in
+            let lhs: String? = pure(append) <*> pure(string)
+            let rhs: String? = pure(append(string))
 
-                // fmap (g . h) = (fmap g) . (fmap h)
-                it("obeys the function composition law") {
-                    let property = generateOptional() { optional in
-                        let lhs = compose(append, prepend) <^> optional
-                        let rhs = compose(curry(<^>)(append), curry(<^>)(prepend))(optional)
+            return rhs == lhs
+        }
 
-                        return lhs == rhs
-                    }
+        // u <*> pure y = pure ($ y) <*> u
+        property("interchange law") <- forAll { (string: String) in
+            let lhs: String? = pure(append) <*> pure(string)
+            let rhs: String? = pure({ $0(string) }) <*> pure(append)
 
-                    expect(property).to(hold())
-                }
-            }
+            return lhs == rhs
+        }
 
-            describe("apply") {
-                // pure id <*> v = v
-                it("obeys the identity law") {
-                    let property = generateOptional() { optional in
-                        let lhs = pure(id) <*> optional
-                        let rhs = optional
+        // u <*> (v <*> w) = pure (.) <*> u <*> v <*> w
+        property("compospropertyion law") <- forAll { (optional: String?) in
+            let lhs = pure(append) <*> (pure(prepend) <*> optional)
+            let rhs = pure(curry(compose)) <*> pure(append)  <*> pure(prepend) <*> optional
 
-                        return lhs == rhs
-                    }
+            return lhs == rhs
+        }
+    }
 
-                    expect(property).to(hold())
-                }
+    func testMonad() {
+        // return x >>= f = f x
+        property("left identity law") <- forAll { (string: String) in
+            let lhs: String? = pure(string) >>- compose(append, pure)
+            let rhs: String? = compose(append, pure)(string)
 
-                // pure f <*> pure x = pure (f x)
-                it("obeys the homomorphism law") {
-                    let property = generateString() { string in
-                        let lhs: String? = pure(append) <*> pure(string)
-                        let rhs: String? = pure(append(string))
+            return lhs == rhs
+        }
 
-                        return rhs == lhs
-                    }
+        // m >>= return = m
+        property("right identity law") <- forAll { (optional: String?) in
+            let lhs = optional >>- pure
+            let rhs = optional
 
-                    expect(property).to(hold())
-                }
+            return lhs == rhs
+        }
 
-                // u <*> pure y = pure ($ y) <*> u
-                it("obeys the interchange law") {
-                    let property = generateString() { string in
-                        let lhs: String? = pure(append) <*> pure(string)
-                        let rhs: String? = pure({ $0(string) }) <*> pure(append)
+        // (m >>= f) >>= g = m >>= (\x -> f x >>= g)
+        property("associativity law") <- forAll { (optional: String?) in
+            let lhs = (optional >>- compose(append, pure)) >>- compose(prepend, pure)
+            let rhs = optional >>- { x in compose(append, pure)(x) >>- compose(prepend, pure) }
 
-                        return lhs == rhs
-                    }
-
-                    expect(property).to(hold())
-                }
-
-                // u <*> (v <*> w) = pure (.) <*> u <*> v <*> w
-                it("obeys the composition law") {
-                    let property = generateOptional() { optional in
-                        let lhs = pure(append) <*> (pure(prepend) <*> optional)
-                        let rhs = pure(curry(compose)) <*> pure(append)  <*> pure(prepend) <*> optional
-
-                        return lhs == rhs
-                    }
-
-                    expect(property).to(hold())
-                }
-            }
-
-            describe("flatMap") {
-                // return x >>= f = f x
-                it("obeys the left identity law") {
-                    let property = generateString() { string in
-                        let lhs: String? = pure(string) >>- compose(append, pure)
-                        let rhs: String? = compose(append, pure)(string)
-
-                        return lhs == rhs
-                    }
-
-                    expect(property).to(hold())
-                }
-
-                // m >>= return = m
-                it("obeys the right identity law") {
-                    let property = generateOptional() { optional in
-                        let lhs = optional >>- pure
-                        let rhs = optional
-
-                        return lhs == rhs
-                    }
-
-                    expect(property).to(hold())
-                }
-
-                // (m >>= f) >>= g = m >>= (\x -> f x >>= g)
-                it("obeys the associativity law") {
-                    let property = generateOptional() { optional in
-                        let lhs = (optional >>- compose(append, pure)) >>- compose(prepend, pure)
-                        let rhs = optional >>- { x in compose(append, pure)(x) >>- compose(prepend, pure) }
-
-                        return lhs == rhs
-                    }
-
-                    expect(property).to(hold())
-                }
-            }
+            return lhs == rhs
         }
     }
 }

--- a/Tests/Tests/OptionalSpec.swift
+++ b/Tests/Tests/OptionalSpec.swift
@@ -1,6 +1,4 @@
-import func SwiftCheck.property
-import func SwiftCheck.forAll
-import func SwiftCheck.<-
+import SwiftCheck
 import XCTest
 import Runes
 

--- a/Tests/Tests/OptionalSpec.swift
+++ b/Tests/Tests/OptionalSpec.swift
@@ -5,7 +5,7 @@ import Runes
 class OptionalSpec: XCTestCase {
     func testFunctor() {
         // fmap id = id
-        property("identity law") <- forAll { (x: String?) in
+        property("identity law") <- forAll { (x: Int?) in
             let lhs = id <^> x
             let rhs = x
 
@@ -13,7 +13,7 @@ class OptionalSpec: XCTestCase {
         }
 
         // fmap (f . g) = (fmap f) . (fmap g)
-        property("function composition law") <- forAll { (o: OptionalOf<String>, fa: ArrowOf<String, String>, fb: ArrowOf<String, String>) in
+        property("function composition law") <- forAll { (o: OptionalOf<Int>, fa: ArrowOf<Int, Int>, fb: ArrowOf<Int, Int>) in
             let f = fa.getArrow
             let g = fb.getArrow
             let x = o.getOptional
@@ -27,7 +27,7 @@ class OptionalSpec: XCTestCase {
 
     func testApplicative() {
         // pure id <*> v = v
-        property("identity law") <- forAll { (x: String?) in
+        property("identity law") <- forAll { (x: Int?) in
             let lhs = pure(id) <*> x
             let rhs = x
 
@@ -35,17 +35,17 @@ class OptionalSpec: XCTestCase {
         }
 
         // pure f <*> pure x = pure (f x)
-        property("homomorphism law") <- forAll { (x: String, fa: ArrowOf<String, String>) in
+        property("homomorphism law") <- forAll { (x: Int, fa: ArrowOf<Int, Int>) in
             let f = fa.getArrow
 
-            let lhs: String? = pure(f) <*> pure(x)
-            let rhs: String? = pure(f(x))
+            let lhs: Int? = pure(f) <*> pure(x)
+            let rhs: Int? = pure(f(x))
 
             return rhs == lhs
         }
 
         // f <*> pure x = pure ($ x) <*> f
-        property("interchange law") <- forAll { (x: String, fa: OptionalOf<ArrowOf<String, String>>) in
+        property("interchange law") <- forAll { (x: Int, fa: OptionalOf<ArrowOf<Int, Int>>) in
             let f = fa.getOptional?.getArrow
 
             let lhs = f <*> pure(x)
@@ -55,7 +55,7 @@ class OptionalSpec: XCTestCase {
         }
 
         // f <*> (g <*> x) = pure (.) <*> f <*> g <*> x
-        property("composition law") <- forAll { (o: OptionalOf<String>, fa: OptionalOf<ArrowOf<String, String>>, fb: OptionalOf<ArrowOf<String, String>>) in
+        property("composition law") <- forAll { (o: OptionalOf<Int>, fa: OptionalOf<ArrowOf<Int, Int>>, fb: OptionalOf<ArrowOf<Int, Int>>) in
             let x = o.getOptional
             let f = fa.getOptional?.getArrow
             let g = fb.getOptional?.getArrow
@@ -69,8 +69,8 @@ class OptionalSpec: XCTestCase {
 
     func testMonad() {
         // return x >>= f = f x
-        property("left identity law") <- forAll { (x: String, fa: ArrowOf<String, String>) in
-            let f: String -> String? = compose(fa.getArrow, pure)
+        property("left identity law") <- forAll { (x: Int, fa: ArrowOf<Int, Int>) in
+            let f: Int -> Int? = compose(fa.getArrow, pure)
 
             let lhs = pure(x) >>- f
             let rhs = f(x)
@@ -79,7 +79,7 @@ class OptionalSpec: XCTestCase {
         }
 
         // m >>= return = m
-        property("right identity law") <- forAll { (o: OptionalOf<String>) in
+        property("right identity law") <- forAll { (o: OptionalOf<Int>) in
             let x = o.getOptional
 
             let lhs = x >>- pure
@@ -89,10 +89,10 @@ class OptionalSpec: XCTestCase {
         }
 
         // (m >>= f) >>= g = m >>= (\x -> f x >>= g)
-        property("associativity law") <- forAll { (o: OptionalOf<String>, fa: ArrowOf<String, String>, fb: ArrowOf<String, String>) in
+        property("associativity law") <- forAll { (o: OptionalOf<Int>, fa: ArrowOf<Int, Int>, fb: ArrowOf<Int, Int>) in
             let m = o.getOptional
-            let f: String -> String? = compose(fa.getArrow, pure)
-            let g: String -> String? = compose(fb.getArrow, pure)
+            let f: Int -> Int? = compose(fa.getArrow, pure)
+            let g: Int -> Int? = compose(fb.getArrow, pure)
 
             let lhs = (m >>- f) >>- g
             let rhs = m >>- { x in f(x) >>- g }


### PR DESCRIPTION
I really like SwiftCheck's syntax more then Fox. And this removes a
metric fuckload of overhead, since it becomes the only dependency.

Right now, this is pointed at `master`, because I need a new release of
SwiftCheck that doesn't conflict with the operators we define.

See https://github.com/typelift/SwiftCheck/issues/100 for more info.
