### PR TITLE
Monadic composition

### DIFF
--- a/Runes.xcodeproj/project.pbxproj
+++ b/Runes.xcodeproj/project.pbxproj
@@ -178,7 +178,9 @@
 				F8624C321A645AB900C883B3 /* Tests */,
 				F802D4D31A5F218E005E236C /* Products */,
 			);
+			indentWidth = 4;
 			sourceTree = "<group>";
+			usesTabs = 0;
 		};
 		F802D4D31A5F218E005E236C /* Products */ = {
 			isa = PBXGroup;

--- a/Runes.xcodeproj/project.pbxproj
+++ b/Runes.xcodeproj/project.pbxproj
@@ -17,6 +17,9 @@
 		51DE8A2C1BAB373100124320 /* Functions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8624C5C1A647E6F00C883B3 /* Functions.swift */; };
 		51DE8A2D1BAB373100124320 /* OptionalSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8624C371A645B0700C883B3 /* OptionalSpec.swift */; };
 		51DE8A2E1BAB373100124320 /* ArraySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8624C5F1A647EE400C883B3 /* ArraySpec.swift */; };
+		CE3407811C0E9F0A00C84170 /* Operators.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE3407801C0E9F0A00C84170 /* Operators.swift */; };
+		CE3407821C0E9F0A00C84170 /* Operators.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE3407801C0E9F0A00C84170 /* Operators.swift */; };
+		CE3407831C0E9F0A00C84170 /* Operators.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE3407801C0E9F0A00C84170 /* Operators.swift */; };
 		EAA6A5181B2F163B0058E9A8 /* Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A8C7DE71A5F58330050914C /* Array.swift */; };
 		EAA6A5191B2F163B0058E9A8 /* Runes.swift in Sources */ = {isa = PBXBuildFile; fileRef = F802D4EE1A5F2341005E236C /* Runes.swift */; };
 		EAA6A51A1B2F163B0058E9A8 /* Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = F802D4F01A5F23BE005E236C /* Optional.swift */; };
@@ -35,8 +38,8 @@
 		F86B2E241A5F2B9E00C3B8BD /* Runes.h in Headers */ = {isa = PBXBuildFile; fileRef = F802D4D71A5F218E005E236C /* Runes.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F86B2E251A5F2BA400C3B8BD /* Runes.swift in Sources */ = {isa = PBXBuildFile; fileRef = F802D4EE1A5F2341005E236C /* Runes.swift */; };
 		F86B2E261A5F2BA400C3B8BD /* Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = F802D4F01A5F23BE005E236C /* Optional.swift */; };
-		F88DE9731BA3854E00A9D383 /* SwiftCheck.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F88DE9721BA3854E00A9D383 /* SwiftCheck.framework */; settings = {ASSET_TAGS = (); }; };
-		F88DE9751BA3855600A9D383 /* SwiftCheck.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F88DE9741BA3855600A9D383 /* SwiftCheck.framework */; settings = {ASSET_TAGS = (); }; };
+		F88DE9731BA3854E00A9D383 /* SwiftCheck.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F88DE9721BA3854E00A9D383 /* SwiftCheck.framework */; };
+		F88DE9751BA3855600A9D383 /* SwiftCheck.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F88DE9741BA3855600A9D383 /* SwiftCheck.framework */; };
 		F89776E51BA601D500EE823E /* SwiftCheck.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = F88DE9741BA3855600A9D383 /* SwiftCheck.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F89776E61BA601DE00EE823E /* SwiftCheck.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = F88DE9721BA3854E00A9D383 /* SwiftCheck.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
@@ -92,6 +95,7 @@
 		4A8C7DE71A5F58330050914C /* Array.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Array.swift; sourceTree = "<group>"; };
 		51DE8A121BAB363500124320 /* Runes.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Runes.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		51DE8A211BAB36E600124320 /* Runes-tvOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Runes-tvOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		CE3407801C0E9F0A00C84170 /* Operators.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Operators.swift; sourceTree = "<group>"; };
 		EAA6A5101B2F154D0058E9A8 /* Runes.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Runes.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F802D4D21A5F218E005E236C /* Runes.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Runes.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F802D4D61A5F218E005E236C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -267,6 +271,7 @@
 			isa = PBXGroup;
 			children = (
 				F8624C5C1A647E6F00C883B3 /* Functions.swift */,
+				CE3407801C0E9F0A00C84170 /* Operators.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -561,6 +566,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				51DE8A2D1BAB373100124320 /* OptionalSpec.swift in Sources */,
+				CE3407831C0E9F0A00C84170 /* Operators.swift in Sources */,
 				51DE8A2C1BAB373100124320 /* Functions.swift in Sources */,
 				51DE8A2E1BAB373100124320 /* ArraySpec.swift in Sources */,
 			);
@@ -591,6 +597,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F8624C381A645B0700C883B3 /* OptionalSpec.swift in Sources */,
+				CE3407811C0E9F0A00C84170 /* Operators.swift in Sources */,
 				F8624C5E1A647E7300C883B3 /* Functions.swift in Sources */,
 				F8624C601A647EE400C883B3 /* ArraySpec.swift in Sources */,
 			);
@@ -601,6 +608,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F8624C511A645CB900C883B3 /* OptionalSpec.swift in Sources */,
+				CE3407821C0E9F0A00C84170 /* Operators.swift in Sources */,
 				F8624C5D1A647E6F00C883B3 /* Functions.swift in Sources */,
 				F8624C611A647FB300C883B3 /* ArraySpec.swift in Sources */,
 			);

--- a/Source/Array.swift
+++ b/Source/Array.swift
@@ -55,6 +55,34 @@ public func -<< <T, U>(f: T -> [U], a: [T]) -> [U] {
 }
 
 /**
+    compose two functions that produce arrays of values, from left to right
+
+    produces a function that applies that flatMaps the second function over each element in the result of the first function
+
+    - parameter f: A transformation function from type `A` to type `[B]`
+    - parameter g: A transformation function from type `B` to type `[C]`
+
+    - returns: A value of type `[C]`
+*/
+public func >-> <A, B, C>(f: A -> [B], g: B -> [C]) -> A -> [C] {
+    return { x in f(x) >>- g }
+}
+
+/**
+    compose two functions that produce arrays of values, from right to left
+
+    produces a function that applies that flatMaps the first function over each element in the result of the second function
+
+    - parameter f: A transformation function from type `B` to type `[C]`
+    - parameter g: A transformation function from type `A` to type `[B]`
+
+    - returns: A value of type `[C]`
+*/
+public func <-< <A, B, C>(f: B -> [C], g: A -> [B]) -> A -> [C] {
+    return { x in g(x) >>- f }
+}
+
+/**
     Wrap a value in a minimal context of `[]`
 
     - parameter a: A value of type `T`

--- a/Source/Optional.swift
+++ b/Source/Optional.swift
@@ -59,6 +59,36 @@ public func -<< <T, U>(@noescape f: T -> U?, a: T?) -> U? {
 }
 
 /**
+    compose two functions that produce optional values, from left to right
+
+    - If the result of the first function is `.None`, the second function will not be inoked and this will return `.None`
+    - If the result of the first function is `.Some`, the value is unwrapped and passed to the second function which may return `.None`
+
+    - parameter f: A transformation function from type `A` to type `Optional<B>`
+    - parameter g: A transformation function from type `B` to type `Optional<C>`
+
+    - returns: A function from type `A` to type `Optional<C>`
+*/
+public func >-> <A, B, C>(f: A -> B?, g: B -> C?) -> A -> C? {
+    return { x in f(x) >>- g }
+}
+
+/**
+    compose two functions that produce optional values, from right to left
+
+    - If the result of the first function is `.None`, the second function will not be inoked and this will return `.None`
+    - If the result of the first function is `.Some`, the value is unwrapped and passed to the second function which may return `.None`
+
+    - parameter f: A transformation function from type `B` to type `Optional<C>`
+    - parameter g: A transformation function from type `A` to type `Optional<B>`
+
+    - returns: A function from type `A` to type `Optional<C>`
+ */
+public func <-< <A, B, C>(f: B -> C?, g: A -> B?) -> A -> C? {
+    return { x in g(x) >>- f }
+}
+
+/**
     Wrap a value in a minimal context of `.Some`
 
     - parameter a: A value of type `T`

--- a/Source/Runes.swift
+++ b/Source/Runes.swift
@@ -50,3 +50,29 @@ infix operator -<< {
     // operator (`=`)
     precedence 100
 }
+
+/**
+compose two functions that produce results in a context, from left to right, returning a result in that context
+
+Expected function type: `(a -> m b) -> (b -> m c) -> a -> m c`
+*/
+infix operator >-> {
+    associativity right
+
+    // Same precedence as `>>-` and `-<<`.
+    precedence 100
+}
+
+/**
+compose two functions that produce results in a context, from right to left, returning a result in that context
+
+like `>->`, but with the arguments flipped
+
+Expected function type: `(b -> m c) -> (a -> m b) -> a -> m c`
+*/
+infix operator <-< {
+    associativity right
+
+    // Same precedence as `>>-` and `-<<`.
+    precedence 100
+}

--- a/Tests/Helpers/Functions.swift
+++ b/Tests/Helpers/Functions.swift
@@ -2,10 +2,6 @@ func id<A>(a: A) -> A {
     return a
 }
 
-func compose<A, B, C>(f: B -> C, _ g: A -> B) -> A -> C {
-    return { x in f(g(x)) }
-}
-
 func curry<A, B, C>(f: (A, B) -> C) -> A -> B -> C {
     return { a in { b in f(a, b) }}
 }

--- a/Tests/Helpers/Operators.swift
+++ b/Tests/Helpers/Operators.swift
@@ -1,0 +1,8 @@
+infix operator • {
+    associativity right
+    precedence 170
+}
+
+func • <A, B, C> (f: B -> C, g: A -> B) -> A -> C {
+    return { x in f(g(x)) }
+}

--- a/Tests/Tests/ArraySpec.swift
+++ b/Tests/Tests/ArraySpec.swift
@@ -97,5 +97,29 @@ class ArraySpec: XCTestCase {
 
             return lhs == rhs
         }
+
+        // (f >=> g) >=> h = f >=> (g >=> h)
+        property("left-to-right Kleisli composition of monads") <- forAll { (x: Int, fa: ArrowOf<Int, Int>, fb: ArrowOf<Int, Int>, fc: ArrowOf<Int, Int>) in
+            let f: Int -> [Int] = pure • fa.getArrow
+            let g: Int -> [Int] = pure • fb.getArrow
+            let h: Int -> [Int] = pure • fc.getArrow
+
+            let lhs = (f >-> g) >-> h
+            let rhs = f >-> (g >-> h)
+
+            return lhs(x) == rhs(x)
+        }
+
+        // (f <=< g) <=< h = f <=< (g <=< h)
+        property("right-to-left Kleisli composition of monads") <- forAll { (x: Int, fa: ArrowOf<Int, Int>, fb: ArrowOf<Int, Int>, fc: ArrowOf<Int, Int>) in
+            let f: Int -> [Int] = pure • fa.getArrow
+            let g: Int -> [Int] = pure • fb.getArrow
+            let h: Int -> [Int] = pure • fc.getArrow
+
+            let lhs = (f <-< g) <-< h
+            let rhs = f <-< (g <-< h)
+
+            return lhs(x) == rhs(x)
+        }
     }
 }

--- a/Tests/Tests/ArraySpec.swift
+++ b/Tests/Tests/ArraySpec.swift
@@ -18,8 +18,8 @@ class ArraySpec: XCTestCase {
             let f = fa.getArrow
             let g = fb.getArrow
 
-            let lhs = compose(f, g) <^> xs
-            let rhs = compose(curry(<^>)(f), curry(<^>)(g))(xs)
+            let lhs = f • g <^> xs
+            let rhs = (curry(<^>)(f) • curry(<^>)(g))(xs)
 
             return lhs == rhs
         }
@@ -61,7 +61,7 @@ class ArraySpec: XCTestCase {
             let g = fb.getArray.map { $0.getArrow }
 
             let lhs = f <*> (g <*> x)
-            let rhs = pure(curry(compose)) <*> f <*> g <*> x
+            let rhs = pure(curry(•)) <*> f <*> g <*> x
 
             return lhs == rhs
         }
@@ -70,7 +70,7 @@ class ArraySpec: XCTestCase {
     func testMonad() {
         // return x >>= f = f x
         property("left identity law") <- forAll { (x: Int, fa: ArrowOf<Int, Int>) in
-            let f: Int -> [Int] = compose(pure, fa.getArrow)
+            let f: Int -> [Int] = pure • fa.getArrow
 
             let lhs = pure(x) >>- f
             let rhs = f(x)
@@ -89,8 +89,8 @@ class ArraySpec: XCTestCase {
         // (m >>= f) >>= g = m >>= (\x -> f x >>= g)
         property("associativity law") <- forAll { (a: ArrayOf<Int>, fa: ArrowOf<Int, Int>, fb: ArrowOf<Int, Int>) in
             let m = a.getArray
-            let f: Int -> [Int] = compose(pure, fa.getArrow)
-            let g: Int -> [Int] = compose(pure, fb.getArrow)
+            let f: Int -> [Int] = pure • fa.getArrow
+            let g: Int -> [Int] = pure • fb.getArrow
 
             let lhs = (m >>- f) >>- g
             let rhs = m >>- { x in f(x) >>- g }

--- a/Tests/Tests/OptionalSpec.swift
+++ b/Tests/Tests/OptionalSpec.swift
@@ -99,5 +99,29 @@ class OptionalSpec: XCTestCase {
 
             return lhs == rhs
         }
+
+        // (f >=> g) >=> h = f >=> (g >=> h)
+        property("left-to-right Kleisli composition of monads") <- forAll { (x: Int, fa: ArrowOf<Int, Int>, fb: ArrowOf<Int, Int>, fc: ArrowOf<Int, Int>) in
+            let f: Int -> Int? = pure • fa.getArrow
+            let g: Int -> Int? = pure • fb.getArrow
+            let h: Int -> Int? = pure • fc.getArrow
+
+            let lhs = (f >-> g) >-> h
+            let rhs = f >-> (g >-> h)
+
+            return lhs(x) == rhs(x)
+        }
+
+        // (f <=< g) <=< h = f <=< (g <=< h)
+        property("right-to-left Kleisli composition of monads") <- forAll { (x: Int, fa: ArrowOf<Int, Int>, fb: ArrowOf<Int, Int>, fc: ArrowOf<Int, Int>) in
+            let f: Int -> Int? = pure • fa.getArrow
+            let g: Int -> Int? = pure • fb.getArrow
+            let h: Int -> Int? = pure • fc.getArrow
+
+            let lhs = (f <-< g) <-< h
+            let rhs = f <-< (g <-< h)
+
+            return lhs(x) == rhs(x)
+        }
     }
 }

--- a/Tests/Tests/OptionalSpec.swift
+++ b/Tests/Tests/OptionalSpec.swift
@@ -18,8 +18,8 @@ class OptionalSpec: XCTestCase {
             let g = fb.getArrow
             let x = o.getOptional
 
-            let lhs = compose(f, g) <^> x
-            let rhs = compose(curry(<^>)(f), curry(<^>)(g))(x)
+            let lhs = f • g <^> x
+            let rhs = (curry(<^>)(f) • curry(<^>)(g))(x)
 
             return lhs == rhs
         }
@@ -61,7 +61,7 @@ class OptionalSpec: XCTestCase {
             let g = fb.getOptional?.getArrow
 
             let lhs = f <*> (g <*> x)
-            let rhs = pure(curry(compose)) <*> f <*> g <*> x
+            let rhs = pure(curry(•)) <*> f <*> g <*> x
 
             return lhs == rhs
         }
@@ -70,7 +70,7 @@ class OptionalSpec: XCTestCase {
     func testMonad() {
         // return x >>= f = f x
         property("left identity law") <- forAll { (x: Int, fa: ArrowOf<Int, Int>) in
-            let f: Int -> Int? = compose(pure, fa.getArrow)
+            let f: Int -> Int? = pure • fa.getArrow
 
             let lhs = pure(x) >>- f
             let rhs = f(x)
@@ -91,8 +91,8 @@ class OptionalSpec: XCTestCase {
         // (m >>= f) >>= g = m >>= (\x -> f x >>= g)
         property("associativity law") <- forAll { (o: OptionalOf<Int>, fa: ArrowOf<Int, Int>, fb: ArrowOf<Int, Int>) in
             let m = o.getOptional
-            let f: Int -> Int? = compose(pure, fa.getArrow)
-            let g: Int -> Int? = compose(pure, fb.getArrow)
+            let f: Int -> Int? = pure • fa.getArrow
+            let g: Int -> Int? = pure • fb.getArrow
 
             let lhs = (m >>- f) >>- g
             let rhs = m >>- { x in f(x) >>- g }


### PR DESCRIPTION
#### Monadic composition

Here's how I'm using this with Result and RAC:

``` swift
request(.GET, "/myendpoint")
  .flatMap(.Concat, transform: SignalProducer.init • (parseJSON >-> decodeSomething))
```

Basically, this really helps to avoid explicit closures everywhere, which I value for both readability and the avoidance of capturing strong references to `self`.

---
#### The composition operator

In the example above I'm using `•` as the composition operator (which can be typed on US keyboards with Opt-8). I threw this into the specs for this PR, because I think it really helps their clarity.

I'd love your feedback on:
- Whether you agree about the improvement to the specs
- What you think about adding this to the public API of Runes in a subsequent commit
