### PR TITLE
Adding @noescape to `map` operator for `Array`

### DIFF
--- a/Source/Array.swift
+++ b/Source/Array.swift
@@ -8,7 +8,7 @@
 
     - returns: A value of type `[U]`
 */
-public func <^> <T, U>(f: T -> U, a: [T]) -> [U] {
+public func <^> <T, U>(@noescape f: T -> U, a: [T]) -> [U] {
     return a.map(f)
 }
 


### PR DESCRIPTION
On `CollectionType`, `map`'s transform function is @noescape, this function can be too.
