### PR TITLE
Update Xcode version on CI

### DIFF
--- a/bin/install-carthage
+++ b/bin/install-carthage
@@ -1,6 +1,0 @@
-#!/usr/bin/env sh
-
-version=0.9.4
-
-curl -L -O "https://github.com/Carthage/Carthage/releases/download/$version/Carthage.pkg"
-sudo installer -pkg Carthage.pkg -target /

--- a/circle.yml
+++ b/circle.yml
@@ -1,10 +1,8 @@
 machine:
   xcode:
-    version: "7.0"
+    version: "7.1"
 
 dependencies:
-  pre:
-    - bin/install-carthage
   override:
     - bin/carthage-bootstrap-if-needed
   cache_directories:


### PR DESCRIPTION
Circle supports up to Xcode 7.1 now. In addition, they are
pre-installing Carthage, so we shouldn't need to install it manually
anymore.
