### PR TITLE
Adding Swift Package Manager specs.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,5 @@
+import PackageDescription
+
+let package = Package (
+  name: "Runes"
+)


### PR DESCRIPTION
Pull request just adds Swift Package Manager spec file `Package.swift`.

**Warning**: Will work only for next version.

SPM uses tags for package versioning.  So it gonna look for latest(greatest) version tag in git repo, clone it and then gonna look for `Package.swift` in root. 

Current version `3.2.0` has no such file, so it will fail.
After this pull request will be merged and new version tag pushed to repo (`>= 3.2.0`) SPM will work.
