### PR TITLE
Add Applicative `*>`, `<*`, and Alternative `<|>` operators

### DIFF
--- a/Source/Runes.swift
+++ b/Source/Runes.swift
@@ -2,7 +2,7 @@
 map a function over a value with context
 
 Expected function type: `(a -> b) -> f a -> f b`
-
+Haskell `infixl 4`
 */
 infix operator <^> {
     associativity left
@@ -15,6 +15,7 @@ infix operator <^> {
 apply a function with context to a value with context
 
 Expected function type: `f (a -> b) -> f a -> f b`
+Haskell `infixl 4`
 */
 infix operator <*> {
     associativity left
@@ -24,9 +25,45 @@ infix operator <*> {
 }
 
 /**
+sequence actions, discarding right (value of the second argument)
+
+Expected function type: `f a -> f b -> f a`
+Haskell `infixl 4`
+*/
+infix operator <* {
+    associativity left
+    precedence 140
+}
+
+/**
+sequence actions, discarding left (value of the first argument)
+
+Expected function type: `f a -> f b -> f b`
+Haskell `infixl 4`
+*/
+infix operator *> {
+    associativity left
+    precedence 140
+}
+
+/**
+an associative binary operation
+
+Expected function type: `f a -> f a -> f a`
+Haskell `infixl 3`
+*/
+infix operator <|> {
+    associativity left
+
+    // Lower precedence than `<^>`, `<*>`, `*>`, `<*`
+    precedence 120
+}
+
+/**
 map a function over a value with context and flatten the result
 
 Expected function type: `m a -> (a -> m b) -> m b`
+Haskell `infixl 1`
 */
 infix operator >>- {
     associativity left
@@ -41,6 +78,7 @@ infix operator >>- {
 map a function over a value with context and flatten the result
 
 Expected function type: `(a -> m b) -> m a -> m b`
+Haskell `infixr 1`
 */
 infix operator -<< {
     associativity right
@@ -52,9 +90,11 @@ infix operator -<< {
 }
 
 /**
-compose two functions that produce results in a context, from left to right, returning a result in that context
+compose two functions that produce results in a context,
+from left to right, returning a result in that context
 
 Expected function type: `(a -> m b) -> (b -> m c) -> a -> m c`
+Haskell `infixr 1`
 */
 infix operator >-> {
     associativity right
@@ -64,11 +104,13 @@ infix operator >-> {
 }
 
 /**
-compose two functions that produce results in a context, from right to left, returning a result in that context
+compose two functions that produce results in a context,
+from right to left, returning a result in that context
 
 like `>->`, but with the arguments flipped
 
 Expected function type: `(b -> m c) -> (a -> m b) -> a -> m c`
+Haskell `infixr 1`
 */
 infix operator <-< {
     associativity right


### PR DESCRIPTION
This pull request adds new Applicative `*>`, `<*`, and Alternative `<|>` operators, which are needed feature in https://github.com/tryswift/TryParsec/pull/11 and all other functional libraries :sparkles: (See also: #65)

By the way, Argo is currently using the same `<|>` operator in [Alternative.swift#L13](https://github.com/thoughtbot/Argo/blob/255196cabc3d84477ba9cd7677c16443cf87775c/Argo/Types/Decoded/Alternative.swift#L13) with `precedence 140`, but this causes continuous monadic operations not working nicely. For example, `m1 *> m2 <|> m3 *> m4` doesn't work and must use parenthesis to work around like `(m1 *> m2) <|> (m3 *> m4)`, which is very cumbersome. Since Haskell uses lower precedence for `<|>`, I have dropped it down to `precedence 120` (or, `precedence 125` might be a better choice as discussed in https://github.com/tryswift/TryParsec/pull/11).

I also added comments about Haskell's infix operator precedences for comparison with Runes :eyes: 
