### PR TITLE
Various fixes

### DIFF
--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,1 +1,1 @@
-github "typelift/SwiftCheck" "swift3_0"
+github "typelift/SwiftCheck" "swift-develop"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "typelift/SwiftCheck" "68638b973ea52bef73451950598397d77b0f003c"
+github "typelift/SwiftCheck" "8365d2830be4a2a6a8ec4b702e3fa53b309515fa"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "typelift/SwiftCheck" "8365d2830be4a2a6a8ec4b702e3fa53b309515fa"
+github "typelift/SwiftCheck" "bd5d620660b3fb2356dea89573baa99e7f3c1c28"

--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,5 @@
 import PackageDescription
 
 let package = Package(
-    name: "Runes"
+  name: "Runes"
 )

--- a/Runes.xcodeproj/project.pbxproj
+++ b/Runes.xcodeproj/project.pbxproj
@@ -23,7 +23,6 @@
 		F802D4F11A5F23BE005E236C /* Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = F802D4F01A5F23BE005E236C /* Optional.swift */; };
 		F80721571D4BE47500882F0F /* SwiftCheck.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F88DE9721BA3854E00A9D383 /* SwiftCheck.framework */; };
 		F80721581D4BE48E00882F0F /* SwiftCheck.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F88DE9741BA3855600A9D383 /* SwiftCheck.framework */; };
-		F80721591D4BE49200882F0F /* SwiftCheck.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F80D6AE61D4BE1B800505CE9 /* SwiftCheck.framework */; };
 		F80D6AD91D4BE10B00505CE9 /* ArraySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = F80D6AD51D4BE10B00505CE9 /* ArraySpec.swift */; };
 		F80D6ADA1D4BE10B00505CE9 /* ArraySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = F80D6AD51D4BE10B00505CE9 /* ArraySpec.swift */; };
 		F80D6ADB1D4BE10B00505CE9 /* ArraySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = F80D6AD51D4BE10B00505CE9 /* ArraySpec.swift */; };
@@ -43,6 +42,8 @@
 		F86B2E261A5F2BA400C3B8BD /* Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = F802D4F01A5F23BE005E236C /* Optional.swift */; };
 		F89776E51BA601D500EE823E /* SwiftCheck.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = F88DE9741BA3855600A9D383 /* SwiftCheck.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F89776E61BA601DE00EE823E /* SwiftCheck.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = F88DE9721BA3854E00A9D383 /* SwiftCheck.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		F8D430A71D5A66A800548DF0 /* SwiftCheck.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = F80D6AE61D4BE1B800505CE9 /* SwiftCheck.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		F8D430A81D5A670000548DF0 /* SwiftCheck.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F80D6AE61D4BE1B800505CE9 /* SwiftCheck.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -90,6 +91,16 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		F8D430A61D5A66A100548DF0 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				F8D430A71D5A66A800548DF0 /* SwiftCheck.framework in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
@@ -127,7 +138,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				51DE8A261BAB36E600124320 /* Runes.framework in Frameworks */,
-				F80721591D4BE49200882F0F /* SwiftCheck.framework in Frameworks */,
+				F8D430A81D5A670000548DF0 /* SwiftCheck.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -336,6 +347,7 @@
 				51DE8A1D1BAB36E600124320 /* Sources */,
 				51DE8A1E1BAB36E600124320 /* Frameworks */,
 				51DE8A1F1BAB36E600124320 /* Resources */,
+				F8D430A61D5A66A100548DF0 /* CopyFiles */,
 			);
 			buildRules = (
 			);

--- a/Runes.xcodeproj/project.pbxproj
+++ b/Runes.xcodeproj/project.pbxproj
@@ -695,6 +695,7 @@
 		51DE8A2A1BAB36E600124320 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -713,6 +714,7 @@
 		51DE8A2B1BAB36E600124320 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -732,7 +734,6 @@
 		EAA6A5151B2F154D0058E9A8 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -754,7 +755,6 @@
 		EAA6A5161B2F154D0058E9A8 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -778,6 +778,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -828,6 +829,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -869,7 +871,6 @@
 		F802D4E91A5F218E005E236C /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -888,7 +889,6 @@
 		F802D4EA1A5F218E005E236C /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -907,6 +907,7 @@
 		F8624C2F1A645A9600C883B3 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = NO;
 				CLANG_ENABLE_MODULES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -928,6 +929,7 @@
 		F8624C301A645A9600C883B3 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = NO;
 				CLANG_ENABLE_MODULES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -945,6 +947,7 @@
 		F8624C4F1A645C9500C883B3 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = NO;
 				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -966,6 +969,7 @@
 		F8624C501A645C9500C883B3 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = NO;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				FRAMEWORK_SEARCH_PATHS = (
@@ -985,7 +989,6 @@
 		F86B2E1F1A5F2B8D00C3B8BD /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1010,7 +1013,6 @@
 		F86B2E201A5F2B8D00C3B8BD /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEFINES_MODULE = YES;

--- a/Sources/Array.swift
+++ b/Sources/Array.swift
@@ -8,7 +8,7 @@
 
     - returns: A value of type `[U]`
 */
-public func <^> <T, U>(f: @noescape (T) -> U, a: [T]) -> [U] {
+public func <^> <T, U>(f: (T) -> U, a: [T]) -> [U] {
     return a.map(f)
 }
 
@@ -64,7 +64,7 @@ public func -<< <T, U>(f: (T) -> [U], a: [T]) -> [U] {
 
     - returns: A value of type `[V]`
 */
-public func >-> <T, U, V>(f: (T) -> [U], g: (U) -> [V]) -> (T) -> [V] {
+public func >-> <T, U, V>(f: @escaping (T) -> [U], g: @escaping (U) -> [V]) -> (T) -> [V] {
     return { x in f(x) >>- g }
 }
 
@@ -78,7 +78,7 @@ public func >-> <T, U, V>(f: (T) -> [U], g: (U) -> [V]) -> (T) -> [V] {
 
     - returns: A value of type `[V]`
 */
-public func <-< <T, U, V>(f: (U) -> [V], g: (T) -> [U]) -> (T) -> [V] {
+public func <-< <T, U, V>(f: @escaping (U) -> [V], g: @escaping (T) -> [U]) -> (T) -> [V] {
     return { x in g(x) >>- f }
 }
 

--- a/Sources/Optional.swift
+++ b/Sources/Optional.swift
@@ -9,7 +9,7 @@
 
     - returns: A value of type `Optional<U>`
 */
-public func <^> <T, U>(f: @noescape (T) -> U, a: T?) -> U? {
+public func <^> <T, U>(f: (T) -> U, a: T?) -> U? {
     return a.map(f)
 }
 
@@ -39,7 +39,7 @@ public func <*> <T, U>(f: ((T) -> U)?, a: T?) -> U? {
 
     - returns: A value of type `Optional<U>`
 */
-public func >>- <T, U>(a: T?, f: @noescape (T) -> U?) -> U? {
+public func >>- <T, U>(a: T?, f: (T) -> U?) -> U? {
     return a.flatMap(f)
 }
 
@@ -54,7 +54,7 @@ public func >>- <T, U>(a: T?, f: @noescape (T) -> U?) -> U? {
 
     - returns: A value of type `Optional<U>`
 */
-public func -<< <T, U>(f: @noescape (T) -> U?, a: T?) -> U? {
+public func -<< <T, U>(f: (T) -> U?, a: T?) -> U? {
   return a.flatMap(f)
 }
 
@@ -69,7 +69,7 @@ public func -<< <T, U>(f: @noescape (T) -> U?, a: T?) -> U? {
 
     - returns: A function from type `T` to type `Optional<V>`
 */
-public func >-> <T, U, V>(f: (T) -> U?, g: (U) -> V?) -> (T) -> V? {
+public func >-> <T, U, V>(f: @escaping (T) -> U?, g: @escaping (U) -> V?) -> (T) -> V? {
     return { x in f(x) >>- g }
 }
 
@@ -84,7 +84,7 @@ public func >-> <T, U, V>(f: (T) -> U?, g: (U) -> V?) -> (T) -> V? {
 
     - returns: A function from type `T` to type `Optional<V>`
  */
-public func <-< <T, U, V>(f: (U) -> V?, g: (T) -> U?) -> (T) -> V? {
+public func <-< <T, U, V>(f: @escaping (U) -> V?, g: @escaping (T) -> U?) -> (T) -> V? {
     return { x in g(x) >>- f }
 }
 

--- a/Sources/Runes.swift
+++ b/Sources/Runes.swift
@@ -12,17 +12,20 @@ precedencegroup MonadicPrecedenceLeft {
 
 precedencegroup AlternativePrecedence {
     associativity: left
-    higherThan: MonadicPrecedenceLeft
+    higherThan: LogicalConjunctionPrecedence
+    lowerThan: ComparisonPrecedence
 }
 
 precedencegroup ApplicativePrecedence {
     associativity: left
     higherThan: AlternativePrecedence
+    lowerThan: NilCoalescingPrecedence
 }
 
 precedencegroup ApplicativeSequencePrecedence {
     associativity: left
     higherThan: ApplicativePrecedence
+    lowerThan: NilCoalescingPrecedence
 }
 
 /**

--- a/Sources/Runes.swift
+++ b/Sources/Runes.swift
@@ -31,7 +31,7 @@ map a function over a value with context
 Expected function type: `(a -> b) -> f a -> f b`
 Haskell `infixl 4`
 */
-infix operator <^>: ApplicativePrecedence
+infix operator <^> : ApplicativePrecedence
 
 /**
 apply a function with context to a value with context
@@ -39,7 +39,7 @@ apply a function with context to a value with context
 Expected function type: `f (a -> b) -> f a -> f b`
 Haskell `infixl 4`
 */
-infix operator <*>: ApplicativePrecedence
+infix operator <*> : ApplicativePrecedence
 
 /**
 sequence actions, discarding right (value of the second argument)
@@ -47,7 +47,7 @@ sequence actions, discarding right (value of the second argument)
 Expected function type: `f a -> f b -> f a`
 Haskell `infixl 4`
 */
-infix operator <*: ApplicativeSequencePrecedence
+infix operator <* : ApplicativeSequencePrecedence
 
 /**
 sequence actions, discarding left (value of the first argument)
@@ -55,7 +55,7 @@ sequence actions, discarding left (value of the first argument)
 Expected function type: `f a -> f b -> f b`
 Haskell `infixl 4`
 */
-infix operator *>: ApplicativeSequencePrecedence
+infix operator *> : ApplicativeSequencePrecedence
 
 /**
 an associative binary operation
@@ -63,7 +63,7 @@ an associative binary operation
 Expected function type: `f a -> f a -> f a`
 Haskell `infixl 3`
 */
-infix operator <|>: AlternativePrecedence
+infix operator <|> : AlternativePrecedence
 
 /**
 map a function over a value with context and flatten the result
@@ -71,7 +71,7 @@ map a function over a value with context and flatten the result
 Expected function type: `m a -> (a -> m b) -> m b`
 Haskell `infixl 1`
 */
-infix operator >>-: MonadicPrecedenceLeft
+infix operator >>- : MonadicPrecedenceLeft
 
 /**
 map a function over a value with context and flatten the result
@@ -79,7 +79,7 @@ map a function over a value with context and flatten the result
 Expected function type: `(a -> m b) -> m a -> m b`
 Haskell `infixr 1`
 */
-infix operator -<<: MonadicPrecedenceRight
+infix operator -<< : MonadicPrecedenceRight
 
 /**
 compose two functions that produce results in a context,
@@ -88,7 +88,7 @@ from left to right, returning a result in that context
 Expected function type: `(a -> m b) -> (b -> m c) -> a -> m c`
 Haskell `infixr 1`
 */
-infix operator >->: MonadicPrecedenceRight
+infix operator >-> : MonadicPrecedenceRight
 
 /**
 compose two functions that produce results in a context,
@@ -99,4 +99,4 @@ like `>->`, but with the arguments flipped
 Expected function type: `(b -> m c) -> (a -> m b) -> a -> m c`
 Haskell `infixr 1`
 */
-infix operator <-<: MonadicPrecedenceRight
+infix operator <-< : MonadicPrecedenceRight

--- a/Sources/Runes.swift
+++ b/Sources/Runes.swift
@@ -1,30 +1,30 @@
-precedencegroup MonadicPrecedenceRight {
+precedencegroup RunesMonadicPrecedenceRight {
     associativity: right
     lowerThan: LogicalDisjunctionPrecedence
     higherThan: AssignmentPrecedence
 }
 
-precedencegroup MonadicPrecedenceLeft {
+precedencegroup RunesMonadicPrecedenceLeft {
     associativity: left
     lowerThan: LogicalDisjunctionPrecedence
     higherThan: AssignmentPrecedence
 }
 
-precedencegroup AlternativePrecedence {
+precedencegroup RunesAlternativePrecedence {
     associativity: left
     higherThan: LogicalConjunctionPrecedence
     lowerThan: ComparisonPrecedence
 }
 
-precedencegroup ApplicativePrecedence {
+precedencegroup RunesApplicativePrecedence {
     associativity: left
-    higherThan: AlternativePrecedence
+    higherThan: RunesAlternativePrecedence
     lowerThan: NilCoalescingPrecedence
 }
 
-precedencegroup ApplicativeSequencePrecedence {
+precedencegroup RunesApplicativeSequencePrecedence {
     associativity: left
-    higherThan: ApplicativePrecedence
+    higherThan: RunesApplicativePrecedence
     lowerThan: NilCoalescingPrecedence
 }
 
@@ -34,7 +34,7 @@ map a function over a value with context
 Expected function type: `(a -> b) -> f a -> f b`
 Haskell `infixl 4`
 */
-infix operator <^> : ApplicativePrecedence
+infix operator <^> : RunesApplicativePrecedence
 
 /**
 apply a function with context to a value with context
@@ -42,7 +42,7 @@ apply a function with context to a value with context
 Expected function type: `f (a -> b) -> f a -> f b`
 Haskell `infixl 4`
 */
-infix operator <*> : ApplicativePrecedence
+infix operator <*> : RunesApplicativePrecedence
 
 /**
 sequence actions, discarding right (value of the second argument)
@@ -50,7 +50,7 @@ sequence actions, discarding right (value of the second argument)
 Expected function type: `f a -> f b -> f a`
 Haskell `infixl 4`
 */
-infix operator <* : ApplicativeSequencePrecedence
+infix operator <* : RunesApplicativeSequencePrecedence
 
 /**
 sequence actions, discarding left (value of the first argument)
@@ -58,7 +58,7 @@ sequence actions, discarding left (value of the first argument)
 Expected function type: `f a -> f b -> f b`
 Haskell `infixl 4`
 */
-infix operator *> : ApplicativeSequencePrecedence
+infix operator *> : RunesApplicativeSequencePrecedence
 
 /**
 an associative binary operation
@@ -66,7 +66,7 @@ an associative binary operation
 Expected function type: `f a -> f a -> f a`
 Haskell `infixl 3`
 */
-infix operator <|> : AlternativePrecedence
+infix operator <|> : RunesAlternativePrecedence
 
 /**
 map a function over a value with context and flatten the result
@@ -74,7 +74,7 @@ map a function over a value with context and flatten the result
 Expected function type: `m a -> (a -> m b) -> m b`
 Haskell `infixl 1`
 */
-infix operator >>- : MonadicPrecedenceLeft
+infix operator >>- : RunesMonadicPrecedenceLeft
 
 /**
 map a function over a value with context and flatten the result
@@ -82,7 +82,7 @@ map a function over a value with context and flatten the result
 Expected function type: `(a -> m b) -> m a -> m b`
 Haskell `infixr 1`
 */
-infix operator -<< : MonadicPrecedenceRight
+infix operator -<< : RunesMonadicPrecedenceRight
 
 /**
 compose two functions that produce results in a context,
@@ -91,7 +91,7 @@ from left to right, returning a result in that context
 Expected function type: `(a -> m b) -> (b -> m c) -> a -> m c`
 Haskell `infixr 1`
 */
-infix operator >-> : MonadicPrecedenceRight
+infix operator >-> : RunesMonadicPrecedenceRight
 
 /**
 compose two functions that produce results in a context,
@@ -102,4 +102,4 @@ like `>->`, but with the arguments flipped
 Expected function type: `(b -> m c) -> (a -> m b) -> a -> m c`
 Haskell `infixr 1`
 */
-infix operator <-< : MonadicPrecedenceRight
+infix operator <-< : RunesMonadicPrecedenceRight

--- a/Sources/Runes.swift
+++ b/Sources/Runes.swift
@@ -1,18 +1,3 @@
-precedencegroup ApplicativePrecedence {
-    associativity: left
-    higherThan: DefaultPrecedence
-}
-
-precedencegroup ApplicativeSequencePrecedence {
-    associativity: left
-    higherThan: ApplicativePrecedence
-}
-
-precedencegroup AlternativePrecedence {
-    associativity: left
-    higherThan: ApplicativeSequencePrecedence
-}
-
 precedencegroup MonadicPrecedenceRight {
     associativity: right
     lowerThan: LogicalDisjunctionPrecedence
@@ -23,6 +8,21 @@ precedencegroup MonadicPrecedenceLeft {
     associativity: left
     lowerThan: LogicalDisjunctionPrecedence
     higherThan: AssignmentPrecedence
+}
+
+precedencegroup AlternativePrecedence {
+    associativity: left
+    higherThan: MonadicPrecedenceLeft
+}
+
+precedencegroup ApplicativePrecedence {
+    associativity: left
+    higherThan: AlternativePrecedence
+}
+
+precedencegroup ApplicativeSequencePrecedence {
+    associativity: left
+    higherThan: ApplicativePrecedence
 }
 
 /**

--- a/Sources/Runes.swift
+++ b/Sources/Runes.swift
@@ -1,15 +1,27 @@
+precedencegroup AlternativePrecedence {
+    associativity: left
+    lowerThan: ComparisonPrecedence
+}
+
+precedencegroup MonadicPrecedenceRight {
+    associativity: right
+    lowerThan: LogicalDisjunctionPrecedence
+    higherThan: AssignmentPrecedence
+}
+
+precedencegroup MonadicPrecedenceLeft {
+    associativity: left
+    lowerThan: LogicalDisjunctionPrecedence
+    higherThan: AssignmentPrecedence
+}
+
 /**
 map a function over a value with context
 
 Expected function type: `(a -> b) -> f a -> f b`
 Haskell `infixl 4`
 */
-infix operator <^> {
-    associativity left
-
-    // Same precedence as the equality operator (`==`)
-    precedence 130
-}
+infix operator <^>: ComparisonPrecedence
 
 /**
 apply a function with context to a value with context
@@ -17,12 +29,7 @@ apply a function with context to a value with context
 Expected function type: `f (a -> b) -> f a -> f b`
 Haskell `infixl 4`
 */
-infix operator <*> {
-    associativity left
-
-    // Same precedence as the equality operator (`==`)
-    precedence 130
-}
+infix operator <*>: ComparisonPrecedence
 
 /**
 sequence actions, discarding right (value of the second argument)
@@ -30,10 +37,7 @@ sequence actions, discarding right (value of the second argument)
 Expected function type: `f a -> f b -> f a`
 Haskell `infixl 4`
 */
-infix operator <* {
-    associativity left
-    precedence 140
-}
+infix operator <*: ComparisonPrecedence
 
 /**
 sequence actions, discarding left (value of the first argument)
@@ -41,10 +45,7 @@ sequence actions, discarding left (value of the first argument)
 Expected function type: `f a -> f b -> f b`
 Haskell `infixl 4`
 */
-infix operator *> {
-    associativity left
-    precedence 140
-}
+infix operator *>: ComparisonPrecedence
 
 /**
 an associative binary operation
@@ -52,12 +53,7 @@ an associative binary operation
 Expected function type: `f a -> f a -> f a`
 Haskell `infixl 3`
 */
-infix operator <|> {
-    associativity left
-
-    // Lower precedence than `<^>`, `<*>`, `*>`, `<*`
-    precedence 120
-}
+infix operator <|>: AlternativePrecedence
 
 /**
 map a function over a value with context and flatten the result
@@ -65,14 +61,7 @@ map a function over a value with context and flatten the result
 Expected function type: `m a -> (a -> m b) -> m b`
 Haskell `infixl 1`
 */
-infix operator >>- {
-    associativity left
-
-    // Lower precedence than the logical comparison operators
-    // (`&&` and `||`), but higher precedence than the assignment
-    // operator (`=`)
-    precedence 100
-}
+infix operator >>-: MonadicPrecedenceLeft
 
 /**
 map a function over a value with context and flatten the result
@@ -80,14 +69,7 @@ map a function over a value with context and flatten the result
 Expected function type: `(a -> m b) -> m a -> m b`
 Haskell `infixr 1`
 */
-infix operator -<< {
-    associativity right
-
-    // Lower precedence than the logical comparison operators
-    // (`&&` and `||`), but higher precedence than the assignment
-    // operator (`=`)
-    precedence 100
-}
+infix operator -<<: MonadicPrecedenceRight
 
 /**
 compose two functions that produce results in a context,
@@ -96,12 +78,7 @@ from left to right, returning a result in that context
 Expected function type: `(a -> m b) -> (b -> m c) -> a -> m c`
 Haskell `infixr 1`
 */
-infix operator >-> {
-    associativity right
-
-    // Same precedence as `>>-` and `-<<`.
-    precedence 100
-}
+infix operator >->: MonadicPrecedenceRight
 
 /**
 compose two functions that produce results in a context,
@@ -112,9 +89,4 @@ like `>->`, but with the arguments flipped
 Expected function type: `(b -> m c) -> (a -> m b) -> a -> m c`
 Haskell `infixr 1`
 */
-infix operator <-< {
-    associativity right
-
-    // Same precedence as `>>-` and `-<<`.
-    precedence 100
-}
+infix operator <-<: MonadicPrecedenceRight

--- a/Sources/Runes.swift
+++ b/Sources/Runes.swift
@@ -1,6 +1,16 @@
+precedencegroup ApplicativePrecedence {
+    associativity: left
+    higherThan: DefaultPrecedence
+}
+
+precedencegroup ApplicativeSequencePrecedence {
+    associativity: left
+    higherThan: ApplicativePrecedence
+}
+
 precedencegroup AlternativePrecedence {
     associativity: left
-    lowerThan: ComparisonPrecedence
+    higherThan: ApplicativeSequencePrecedence
 }
 
 precedencegroup MonadicPrecedenceRight {
@@ -21,7 +31,7 @@ map a function over a value with context
 Expected function type: `(a -> b) -> f a -> f b`
 Haskell `infixl 4`
 */
-infix operator <^>: ComparisonPrecedence
+infix operator <^>: ApplicativePrecedence
 
 /**
 apply a function with context to a value with context
@@ -29,7 +39,7 @@ apply a function with context to a value with context
 Expected function type: `f (a -> b) -> f a -> f b`
 Haskell `infixl 4`
 */
-infix operator <*>: ComparisonPrecedence
+infix operator <*>: ApplicativePrecedence
 
 /**
 sequence actions, discarding right (value of the second argument)
@@ -37,7 +47,7 @@ sequence actions, discarding right (value of the second argument)
 Expected function type: `f a -> f b -> f a`
 Haskell `infixl 4`
 */
-infix operator <*: ComparisonPrecedence
+infix operator <*: ApplicativeSequencePrecedence
 
 /**
 sequence actions, discarding left (value of the first argument)
@@ -45,7 +55,7 @@ sequence actions, discarding left (value of the first argument)
 Expected function type: `f a -> f b -> f b`
 Haskell `infixl 4`
 */
-infix operator *>: ComparisonPrecedence
+infix operator *>: ApplicativeSequencePrecedence
 
 /**
 an associative binary operation

--- a/Tests/Runes/Functions.swift
+++ b/Tests/Runes/Functions.swift
@@ -2,6 +2,6 @@ func id<A>(_ a: A) -> A {
     return a
 }
 
-func curry<A, B, C>(_ f: (A, B) -> C) -> (A) -> (B) -> C {
+func curry<A, B, C>(_ f: @escaping (A, B) -> C) -> (A) -> (B) -> C {
     return { a in { b in f(a, b) }}
 }

--- a/Tests/Runes/Operators.swift
+++ b/Tests/Runes/Operators.swift
@@ -3,6 +3,6 @@ infix operator • {
     precedence 170
 }
 
-func • <A, B, C> (f: (B) -> C, g: (A) -> B) -> (A) -> C {
+func • <A, B, C> (f: @escaping (B) -> C, g: @escaping (A) -> B) -> (A) -> C {
     return { x in f(g(x)) }
 }

--- a/Tests/Runes/Operators.swift
+++ b/Tests/Runes/Operators.swift
@@ -1,6 +1,8 @@
+import Runes
+
 precedencegroup CompositionPrecedence {
     associativity: right
-    higherThan: BitwiseShiftPrecedence
+    higherThan: ApplicativeSequencePrecedence
 }
 
 infix operator •: CompositionPrecedence

--- a/Tests/Runes/Operators.swift
+++ b/Tests/Runes/Operators.swift
@@ -1,7 +1,9 @@
-infix operator • {
-    associativity right
-    precedence 170
+precedencegroup CompositionPrecedence {
+    associativity: right
+    higherThan: BitwiseShiftPrecedence
 }
+
+infix operator •: CompositionPrecedence
 
 func • <A, B, C> (f: @escaping (B) -> C, g: @escaping (A) -> B) -> (A) -> C {
     return { x in f(g(x)) }

--- a/Tests/Runes/Operators.swift
+++ b/Tests/Runes/Operators.swift
@@ -2,7 +2,7 @@ import Runes
 
 precedencegroup CompositionPrecedence {
     associativity: right
-    higherThan: ApplicativeSequencePrecedence
+    higherThan: RunesApplicativeSequencePrecedence
 }
 
 infix operator •: CompositionPrecedence


### PR DESCRIPTION
This includes a few things. Some minor (formatting, SwiftCheck update), some
larger (Extension API across all targets, updates for newest version of Swift
3)

Don't know how I feel about these precedence groups, tbh. I don't think I feel
super great about them. Our tests are also _completely_ broken, since it's
apparently impossible to resolve the differences between how we're choosing to
define these operators and how SwiftCheck defines them. No idea what to do
about this.

Fixes #59 
Fixes #78 
