### PR TITLE
Lowercase optional instances in documentation

### DIFF
--- a/Sources/Optional.swift
+++ b/Sources/Optional.swift
@@ -1,9 +1,9 @@
 /**
   map a function over an optional value
 
-  - If the value is `.None`, the function will not be evaluated and this will
-    return `.None`
-  - If the value is `.Some`, the function will be applied to the unwrapped
+  - If the value is `.none`, the function will not be evaluated and this will
+    return `.none`
+  - If the value is `.some`, the function will be applied to the unwrapped
     value
 
   - parameter f: A transformation function from type `T` to type `U`
@@ -18,9 +18,9 @@ public func <^> <T, U>(f: (T) -> U, a: T?) -> U? {
 /**
   apply an optional function to an optional value
 
-  - If either the value or the function are `.None`, the function will not be
-    evaluated and this will return `.None`
-  - If both the value and the function are `.Some`, the function will be
+  - If either the value or the function are `.none`, the function will not be
+    evaluated and this will return `.none`
+  - If both the value and the function are `.some`, the function will be
     applied to the unwrapped value
 
   - parameter f: An optional transformation function from type `T` to type `U`
@@ -35,9 +35,9 @@ public func <*> <T, U>(f: ((T) -> U)?, a: T?) -> U? {
 /**
   flatMap a function over an optional value (left associative)
 
-  - If the value is `.None`, the function will not be evaluated and this will
-    return `.None`
-  - If the value is `.Some`, the function will be applied to the unwrapped
+  - If the value is `.none`, the function will not be evaluated and this will
+    return `.none`
+  - If the value is `.some`, the function will be applied to the unwrapped
     value
 
   - parameter f: A transformation function from type `T` to type `Optional<U>`
@@ -52,9 +52,9 @@ public func >>- <T, U>(a: T?, f: (T) -> U?) -> U? {
 /**
   flatMap a function over an optional value (right associative)
 
-  - If the value is `.None`, the function will not be evaluated and this will
-    return `.None`
-  - If the value is `.Some`, the function will be applied to the unwrapped
+  - If the value is `.none`, the function will not be evaluated and this will
+    return `.none`
+  - If the value is `.some`, the function will be applied to the unwrapped
     value
 
   - parameter a: A value of type `Optional<T>`
@@ -69,10 +69,10 @@ public func -<< <T, U>(f: (T) -> U?, a: T?) -> U? {
 /**
   compose two functions that produce optional values, from left to right
 
-  - If the result of the first function is `.None`, the second function will
-    not be inoked and this will return `.None`
-  - If the result of the first function is `.Some`, the value is unwrapped and
-    passed to the second function which may return `.None`
+  - If the result of the first function is `.none`, the second function will
+    not be inoked and this will return `.none`
+  - If the result of the first function is `.some`, the value is unwrapped and
+    passed to the second function which may return `.none`
 
   - parameter f: A transformation function from type `T` to type `Optional<U>`
   - parameter g: A transformation function from type `U` to type `Optional<V>`
@@ -86,10 +86,10 @@ public func >-> <T, U, V>(f: @escaping (T) -> U?, g: @escaping (U) -> V?) -> (T)
 /**
   compose two functions that produce optional values, from right to left
 
-  - If the result of the first function is `.None`, the second function will
-    not be inoked and this will return `.None`
-  - If the result of the first function is `.Some`, the value is unwrapped and
-    passed to the second function which may return `.None`
+  - If the result of the first function is `.none`, the second function will
+    not be inoked and this will return `.none`
+  - If the result of the first function is `.some`, the value is unwrapped and
+    passed to the second function which may return `.none`
 
   - parameter f: A transformation function from type `U` to type `Optional<V>`
   - parameter g: A transformation function from type `T` to type `Optional<U>`
@@ -101,11 +101,11 @@ public func <-< <T, U, V>(f: @escaping (U) -> V?, g: @escaping (T) -> U?) -> (T)
 }
 
 /**
-  Wrap a value in a minimal context of `.Some`
+  Wrap a value in a minimal context of `.some`
 
   - parameter a: A value of type `T`
 
-  - returns: The provided value wrapped in `.Some`
+  - returns: The provided value wrapped in `.some`
 */
 public func pure<T>(_ a: T) -> T? {
   return .some(a)
@@ -115,9 +115,9 @@ public extension Optional {
   /**
     apply an optional function to `self`
 
-    - If either self or the function are `.None`, the function will not be
-      evaluated and this will return `.None`
-    - If both self and the function are `.Some`, the function will be applied
+    - If either self or the function are `.none`, the function will not be
+      evaluated and this will return `.none`
+    - If both self and the function are `.some`, the function will be applied
       to the unwrapped value
 
     - parameter f: An optional transformation function from type `Wrapped` to type `T`


### PR DESCRIPTION
These were lowercased as a part of Swift 3 but we didn't lowercase them
in our documentation. We should be consistent.