### PR TITLE
Implement Alternative and flesh out Applicative

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,14 @@ correspond to common Haskell typeclasses:
 ### Applicative Functor ###
 
 - `<*>` (pronounced "apply")
+- `<*` (pronounced "left sequence")
+- `*>` (pronounced "right sequence")
 - `pure` (pronounced "pure")
+
+### Alternative ###
+
+- `<|>` (pronounced "alternate")
+- `empty` (pronounced "empty")
 
 ### Monad ###
 
@@ -45,7 +52,13 @@ public func <^> <T, U>(f: T -> U, x: T?) -> U?
 
 // Optional+Applicative:
 public func <*> <T, U>(f: (T -> U)?, x: T?) -> U?
+public func <* <T, U>(lhs: T?, rhs: U?) -> T?
+public func *> <T, U>(lhs: T?, rhs: U?) -> U?
 public func pure<T>(x: T) -> T?
+
+// Optional+Alternative:
+public func <|> <T>(lhs: T?, rhs: T?) -> T?
+public func empty<T>() -> T?
 
 // Optional+Monad:
 public func >>- <T, U>(x: T?, f: T -> U?) -> U?
@@ -58,7 +71,13 @@ public func <^> <T, U>(f: T -> U, x: [T]) -> [U]
 
 // Array+Applicative:
 public func <*> <T, U>(fs: [T -> U], x: [T]) -> [U]
+public func <* <T, U>(lhs: [T], rhs: [U]) -> [T]
+public func *> <T, U>(lhs: [T], rhs: [U]) -> [U]
 public func pure<T>(x: T) -> [T]
+
+// Array+Alternative:
+public func <|> <T>(lhs: [T], rhs: [T]) -> [T]
+public func empty<T>() -> [T]
 
 // Array+Monad:
 public func >>- <T, U>(x: [T], f: T -> [U]) -> [U]

--- a/Runes.xcodeproj/project.pbxproj
+++ b/Runes.xcodeproj/project.pbxproj
@@ -35,6 +35,10 @@
 		F89AAC971D74D04800184D08 /* Mozart.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = F89AAC911D74D00E00184D08 /* Mozart.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F8D430A71D5A66A800548DF0 /* SwiftCheck.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = F80D6AE61D4BE1B800505CE9 /* SwiftCheck.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F8D430A81D5A670000548DF0 /* SwiftCheck.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F80D6AE61D4BE1B800505CE9 /* SwiftCheck.framework */; };
+		F8DDC6EA1DD6754600E173E0 /* Optional+Alternative.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8DDC6E91DD6754600E173E0 /* Optional+Alternative.swift */; };
+		F8DDC6EB1DD6755300E173E0 /* Optional+Alternative.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8DDC6E91DD6754600E173E0 /* Optional+Alternative.swift */; };
+		F8DDC6EC1DD6755300E173E0 /* Optional+Alternative.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8DDC6E91DD6754600E173E0 /* Optional+Alternative.swift */; };
+		F8DDC6ED1DD6755400E173E0 /* Optional+Alternative.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8DDC6E91DD6754600E173E0 /* Optional+Alternative.swift */; };
 		F8E09D1D1DCF83F200816E60 /* Array+Applicative.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E09D151DCF83F200816E60 /* Array+Applicative.swift */; };
 		F8E09D1E1DCF83F200816E60 /* Array+Applicative.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E09D151DCF83F200816E60 /* Array+Applicative.swift */; };
 		F8E09D1F1DCF83F200816E60 /* Array+Applicative.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E09D151DCF83F200816E60 /* Array+Applicative.swift */; };
@@ -144,6 +148,7 @@
 		F89AAC8F1D74D00100184D08 /* Mozart.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Mozart.framework; path = Carthage/Build/Mac/Mozart.framework; sourceTree = SOURCE_ROOT; };
 		F89AAC911D74D00E00184D08 /* Mozart.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Mozart.framework; sourceTree = "<group>"; };
 		F89AAC931D74D01A00184D08 /* Mozart.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Mozart.framework; path = Carthage/Build/iOS/Mozart.framework; sourceTree = SOURCE_ROOT; };
+		F8DDC6E91DD6754600E173E0 /* Optional+Alternative.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Optional+Alternative.swift"; sourceTree = "<group>"; };
 		F8E09D151DCF83F200816E60 /* Array+Applicative.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Array+Applicative.swift"; sourceTree = "<group>"; };
 		F8E09D161DCF83F200816E60 /* Array+Functor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Array+Functor.swift"; sourceTree = "<group>"; };
 		F8E09D171DCF83F200816E60 /* Array+Monad.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Array+Monad.swift"; sourceTree = "<group>"; };
@@ -340,6 +345,7 @@
 		F8E09D181DCF83F200816E60 /* Optional */ = {
 			isa = PBXGroup;
 			children = (
+				F8DDC6E91DD6754600E173E0 /* Optional+Alternative.swift */,
 				F8E09D191DCF83F200816E60 /* Optional+Applicative.swift */,
 				F8E09D1A1DCF83F200816E60 /* Optional+Functor.swift */,
 				F8E09D1B1DCF83F200816E60 /* Optional+Monad.swift */,
@@ -639,6 +645,7 @@
 				F8E09D1F1DCF83F200816E60 /* Array+Applicative.swift in Sources */,
 				F8E09D371DCF83F200816E60 /* Runes.swift in Sources */,
 				F8E09D2F1DCF83F200816E60 /* Optional+Functor.swift in Sources */,
+				F8DDC6EC1DD6755300E173E0 /* Optional+Alternative.swift in Sources */,
 				F8E09D231DCF83F200816E60 /* Array+Functor.swift in Sources */,
 				F8E09D271DCF83F200816E60 /* Array+Monad.swift in Sources */,
 			);
@@ -663,6 +670,7 @@
 				F8E09D201DCF83F200816E60 /* Array+Applicative.swift in Sources */,
 				F8E09D381DCF83F200816E60 /* Runes.swift in Sources */,
 				F8E09D301DCF83F200816E60 /* Optional+Functor.swift in Sources */,
+				F8DDC6ED1DD6755400E173E0 /* Optional+Alternative.swift in Sources */,
 				F8E09D241DCF83F200816E60 /* Array+Functor.swift in Sources */,
 				F8E09D281DCF83F200816E60 /* Array+Monad.swift in Sources */,
 			);
@@ -675,6 +683,7 @@
 				F8E09D291DCF83F200816E60 /* Optional+Applicative.swift in Sources */,
 				F8E09D311DCF83F200816E60 /* Optional+Monad.swift in Sources */,
 				F8E09D1D1DCF83F200816E60 /* Array+Applicative.swift in Sources */,
+				F8DDC6EA1DD6754600E173E0 /* Optional+Alternative.swift in Sources */,
 				F8E09D351DCF83F200816E60 /* Runes.swift in Sources */,
 				F8E09D2D1DCF83F200816E60 /* Optional+Functor.swift in Sources */,
 				F8E09D211DCF83F200816E60 /* Array+Functor.swift in Sources */,
@@ -711,6 +720,7 @@
 				F8E09D1E1DCF83F200816E60 /* Array+Applicative.swift in Sources */,
 				F8E09D361DCF83F200816E60 /* Runes.swift in Sources */,
 				F8E09D2E1DCF83F200816E60 /* Optional+Functor.swift in Sources */,
+				F8DDC6EB1DD6755300E173E0 /* Optional+Alternative.swift in Sources */,
 				F8E09D221DCF83F200816E60 /* Array+Functor.swift in Sources */,
 				F8E09D261DCF83F200816E60 /* Array+Monad.swift in Sources */,
 			);

--- a/Runes.xcodeproj/project.pbxproj
+++ b/Runes.xcodeproj/project.pbxproj
@@ -39,6 +39,10 @@
 		F8DDC6EB1DD6755300E173E0 /* Optional+Alternative.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8DDC6E91DD6754600E173E0 /* Optional+Alternative.swift */; };
 		F8DDC6EC1DD6755300E173E0 /* Optional+Alternative.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8DDC6E91DD6754600E173E0 /* Optional+Alternative.swift */; };
 		F8DDC6ED1DD6755400E173E0 /* Optional+Alternative.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8DDC6E91DD6754600E173E0 /* Optional+Alternative.swift */; };
+		F8DDC6EF1DD67D2600E173E0 /* Array+Alternative.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8DDC6EE1DD67D2600E173E0 /* Array+Alternative.swift */; };
+		F8DDC6F01DD67D2900E173E0 /* Array+Alternative.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8DDC6EE1DD67D2600E173E0 /* Array+Alternative.swift */; };
+		F8DDC6F11DD67D2A00E173E0 /* Array+Alternative.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8DDC6EE1DD67D2600E173E0 /* Array+Alternative.swift */; };
+		F8DDC6F21DD67D2B00E173E0 /* Array+Alternative.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8DDC6EE1DD67D2600E173E0 /* Array+Alternative.swift */; };
 		F8E09D1D1DCF83F200816E60 /* Array+Applicative.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E09D151DCF83F200816E60 /* Array+Applicative.swift */; };
 		F8E09D1E1DCF83F200816E60 /* Array+Applicative.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E09D151DCF83F200816E60 /* Array+Applicative.swift */; };
 		F8E09D1F1DCF83F200816E60 /* Array+Applicative.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E09D151DCF83F200816E60 /* Array+Applicative.swift */; };
@@ -149,6 +153,7 @@
 		F89AAC911D74D00E00184D08 /* Mozart.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Mozart.framework; sourceTree = "<group>"; };
 		F89AAC931D74D01A00184D08 /* Mozart.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Mozart.framework; path = Carthage/Build/iOS/Mozart.framework; sourceTree = SOURCE_ROOT; };
 		F8DDC6E91DD6754600E173E0 /* Optional+Alternative.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Optional+Alternative.swift"; sourceTree = "<group>"; };
+		F8DDC6EE1DD67D2600E173E0 /* Array+Alternative.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Array+Alternative.swift"; sourceTree = "<group>"; };
 		F8E09D151DCF83F200816E60 /* Array+Applicative.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Array+Applicative.swift"; sourceTree = "<group>"; };
 		F8E09D161DCF83F200816E60 /* Array+Functor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Array+Functor.swift"; sourceTree = "<group>"; };
 		F8E09D171DCF83F200816E60 /* Array+Monad.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Array+Monad.swift"; sourceTree = "<group>"; };
@@ -335,6 +340,7 @@
 		F8E09D141DCF83F200816E60 /* Array */ = {
 			isa = PBXGroup;
 			children = (
+				F8DDC6EE1DD67D2600E173E0 /* Array+Alternative.swift */,
 				F8E09D151DCF83F200816E60 /* Array+Applicative.swift */,
 				F8E09D161DCF83F200816E60 /* Array+Functor.swift */,
 				F8E09D171DCF83F200816E60 /* Array+Monad.swift */,
@@ -640,6 +646,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F8DDC6F11DD67D2A00E173E0 /* Array+Alternative.swift in Sources */,
 				F8E09D2B1DCF83F200816E60 /* Optional+Applicative.swift in Sources */,
 				F8E09D331DCF83F200816E60 /* Optional+Monad.swift in Sources */,
 				F8E09D1F1DCF83F200816E60 /* Array+Applicative.swift in Sources */,
@@ -665,6 +672,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F8DDC6F21DD67D2B00E173E0 /* Array+Alternative.swift in Sources */,
 				F8E09D2C1DCF83F200816E60 /* Optional+Applicative.swift in Sources */,
 				F8E09D341DCF83F200816E60 /* Optional+Monad.swift in Sources */,
 				F8E09D201DCF83F200816E60 /* Array+Applicative.swift in Sources */,
@@ -680,6 +688,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F8DDC6EF1DD67D2600E173E0 /* Array+Alternative.swift in Sources */,
 				F8E09D291DCF83F200816E60 /* Optional+Applicative.swift in Sources */,
 				F8E09D311DCF83F200816E60 /* Optional+Monad.swift in Sources */,
 				F8E09D1D1DCF83F200816E60 /* Array+Applicative.swift in Sources */,
@@ -715,6 +724,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F8DDC6F01DD67D2900E173E0 /* Array+Alternative.swift in Sources */,
 				F8E09D2A1DCF83F200816E60 /* Optional+Applicative.swift in Sources */,
 				F8E09D321DCF83F200816E60 /* Optional+Monad.swift in Sources */,
 				F8E09D1E1DCF83F200816E60 /* Array+Applicative.swift in Sources */,

--- a/Sources/Runes/Array/Array+Alternative.swift
+++ b/Sources/Runes/Array/Array+Alternative.swift
@@ -1,0 +1,22 @@
+/**
+  Return the result of concatenating two arrays
+
+  - parameter lhs: A value of type `[T]`
+  - parameter rhs: A value of type `[T]`
+
+  - returns: The result of concatenating `lhs` and `rhs`
+*/
+public func <|> <T>(lhs: [T], rhs: @autoclosure () -> [T]) -> [T] {
+  return lhs + rhs()
+}
+
+/**
+  Return an empty context of `[]`
+
+  This is the dual of `pure`.
+
+  - returns: An instance of `[]` of the type `[T]`
+*/
+public func empty<T>() -> [T] {
+  return []
+}

--- a/Sources/Runes/Array/Array+Applicative.swift
+++ b/Sources/Runes/Array/Array+Applicative.swift
@@ -14,6 +14,56 @@ public func <*> <T, U>(fs: [(T) -> U], a: [T]) -> [U] {
 }
 
 /**
+  Sequence two values, discarding the right hand value
+
+  This will return a new array resulting from repeating each element in `lhs`
+  for each element in `rhs`.
+
+  For example:
+
+  ```
+  let xs = [1, 2, 3]
+  let ys = [4, 5, 6]
+  let zs = xs <* ys // [1, 1, 1, 2, 2, 2, 3, 3, 3]
+  ```
+
+  - parameter lhs: A value of type `[T]`
+  - parameter rhs: A value of type `[U]`
+
+  - returns: a value of type `[T]`
+*/
+public func <* <T, U>(lhs: [T], rhs: [U]) -> [T] {
+  return lhs.reduce([]) { accum, elem in
+    accum + rhs.map { _ in elem }
+  }
+}
+
+/**
+  Sequence two values, discarding the left hand value
+
+  This will return a new array resulting from iterating over `lhs` and
+  appending the elements in `rhs` each time.
+
+  For example:
+
+  ```
+  let xs = [1, 2, 3]
+  let ys = [4, 5, 6]
+  let zs = xs *> ys // [4, 5, 6, 4, 5, 6, 4, 5, 6]
+  ```
+
+  - parameter lhs: A value of type `[T]`
+  - parameter rhs: A value of type `[U]`
+
+  - returns: a value of type `[U]`
+*/
+public func *> <T, U>(lhs: [T], rhs: [U]) -> [U] {
+  return lhs.reduce([]) { accum, _ in
+    accum + rhs
+  }
+}
+
+/**
   Wrap a value in a minimal context of `[]`
 
   - parameter a: A value of type `T`

--- a/Sources/Runes/Optional/Optional+Alternative.swift
+++ b/Sources/Runes/Optional/Optional+Alternative.swift
@@ -1,0 +1,45 @@
+/**
+  Return a successful value or the provided default
+
+  - If the left hand value is `.some`, this will return the left hand value
+  - If the left hand value is `.none`, this will return the default on the
+    right hand side
+
+  - parameter lhs: A value of type `Optional<T>`
+  - parameter rhs: A value of type `Optional<T>`
+
+  - returns: a value of type `Optional<T>`
+*/
+public func <|> <T>(lhs: T?, rhs: @autoclosure () -> T?) -> T? {
+  return lhs.or(rhs)
+}
+
+/**
+  Return an empty context of `.none`
+
+  This is the dual of `pure`.
+
+  - returns: An instance of `.none` of the type `T?`
+*/
+public func empty<T>() -> T? {
+  return .none
+}
+
+public extension Optional {
+  /**
+    Return a successful value or the provided default
+
+    - If `self` is `.some`, this will return `self`
+    - If `self` is `.none`, this will return the provided default
+
+    - parameter other: A value of type `Optional<T>`
+
+    - returns: a value of type `Optional<T>`
+  */
+  func or(_ other: @autoclosure () -> Wrapped?) -> Wrapped? {
+    switch self {
+      case .some: return self
+      case .none: return other()
+    }
+  }
+}

--- a/Sources/Runes/Optional/Optional+Applicative.swift
+++ b/Sources/Runes/Optional/Optional+Applicative.swift
@@ -16,6 +16,42 @@ public func <*> <T, U>(f: ((T) -> U)?, a: T?) -> U? {
 }
 
 /**
+  Sequence two values, discarding the right hand value
+
+  - If the right hand value is `.none`, this will return `.none`
+  - If the right hand value is `.some`, this will return the left hand value
+
+  - parameter lhs: A value of type `Optional<T>`
+  - parameter rhs: A value of type `Optional<U>`
+
+  - returns: a value of type `Optional<T>`
+*/
+public func <* <T, U>(lhs: T?, rhs: U?) -> T? {
+  switch rhs {
+  case .none: return .none
+  case .some: return lhs
+  }
+}
+
+/**
+  Sequence two values, discarding the left hand value
+
+  - If the left hand value is `.none`, this will return `.none`
+  - If the left hand value is `.some`, this will return the right hand value
+
+  - parameter lhs: A value of type `Optional<T>`
+  - parameter rhs: A value of type `Optional<U>`
+
+  - returns: a value of type `Optional<U>`
+*/
+public func *> <T, U>(lhs: T?, rhs: U?) -> U? {
+  switch lhs {
+  case .none: return .none
+  case .some: return rhs
+  }
+}
+
+/**
   Wrap a value in a minimal context of `.some`
 
   - parameter a: A value of type `T`

--- a/Tests/RunesTests/ArraySpec.swift
+++ b/Tests/RunesTests/ArraySpec.swift
@@ -55,6 +55,28 @@ class ArraySpec: XCTestCase {
       return lhs == rhs
     }
 
+    // u *> v = pure (const id) <*> u <*> v
+    property("interchange law - right sequence") <- forAll { (au: ArrayOf<Int>, av: ArrayOf<Int>) in
+      let u = au.getArray
+      let v = av.getArray
+
+      let lhs: [Int] = u *> v
+      let rhs: [Int] = pure(curry(const)(id)) <*> u <*> v
+
+      return lhs == rhs
+    }
+
+    // u <* v = pure const <*> u <*> v
+    property("interchange law - left sequence") <- forAll { (au: ArrayOf<Int>, av: ArrayOf<Int>) in
+      let u = au.getArray
+      let v = av.getArray
+
+      let lhs: [Int] = u <* v
+      let rhs: [Int] = pure(curry(const)) <*> u <*> v
+
+      return lhs == rhs
+    }
+
     // f <*> (g <*> x) = pure (.) <*> f <*> g <*> x
     property("composition law") <- forAll { (a: ArrayOf<Int>, fa: ArrayOf<ArrowOf<Int, Int>>, fb: ArrayOf<ArrowOf<Int, Int>>) in
       let x = a.getArray

--- a/Tests/RunesTests/ArraySpec.swift
+++ b/Tests/RunesTests/ArraySpec.swift
@@ -90,6 +90,29 @@ class ArraySpec: XCTestCase {
     }
   }
 
+  func testAlternative() {
+    property("alternative operator - left empty") <- forAll { (x: Int) in
+      let lhs: [Int] = empty() <|> pure(x)
+      let rhs: [Int] = pure(x)
+
+      return lhs == rhs
+    }
+
+    property("alternative operator - right empty") <- forAll { (x: Int) in
+      let lhs: [Int] = pure(x) <|> empty()
+      let rhs: [Int] = pure(x)
+
+      return lhs == rhs
+    }
+
+    property("alternative operator - neither empty") <- forAll { (x: Int, y: Int) in
+      let lhs: [Int] = pure(x) <|> pure(y)
+      let rhs: [Int] = pure(x) + pure(y)
+
+      return lhs == rhs
+    }
+  }
+
   func testMonad() {
     // return x >>= f = f x
     property("left identity law") <- forAll { (x: Int, fa: ArrowOf<Int, Int>) in

--- a/Tests/RunesTests/Functions.swift
+++ b/Tests/RunesTests/Functions.swift
@@ -1,3 +1,7 @@
+func const<T, U>(x: T, y: U) -> T {
+  return x
+}
+
 func id<A>(_ a: A) -> A {
   return a
 }

--- a/Tests/RunesTests/OptionalSpec.swift
+++ b/Tests/RunesTests/OptionalSpec.swift
@@ -55,6 +55,28 @@ class OptionalSpec: XCTestCase {
       return lhs == rhs
     }
 
+    // u *> v = pure (const id) <*> u <*> v
+    property("interchange law - right sequence") <- forAll { (ou: OptionalOf<Int>, ov: OptionalOf<Int>) in
+      let u = ou.getOptional
+      let v = ov.getOptional
+
+      let lhs = u *> v
+      let rhs = pure(curry(const)(id)) <*> u <*> v
+
+      return lhs == rhs
+    }
+
+    // u <* v = pure const <*> u <*> v
+    property("interchange law - left sequence") <- forAll { (ou: OptionalOf<Int>, ov: OptionalOf<Int>) in
+      let u = ou.getOptional
+      let v = ov.getOptional
+
+      let lhs = u <* v
+      let rhs = pure(curry(const)) <*> u <*> v
+
+      return lhs == rhs
+    }
+
     // f <*> (g <*> x) = pure (.) <*> f <*> g <*> x
     property("composition law") <- forAll { (o: OptionalOf<Int>, fa: OptionalOf<ArrowOf<Int, Int>>, fb: OptionalOf<ArrowOf<Int, Int>>) in
       let x = o.getOptional

--- a/Tests/RunesTests/OptionalSpec.swift
+++ b/Tests/RunesTests/OptionalSpec.swift
@@ -90,6 +90,29 @@ class OptionalSpec: XCTestCase {
     }
   }
 
+  func testAlternative() {
+    property("alternative operator - left empty") <- forAll { (x: Int) in
+      let lhs: Int? = empty() <|> pure(x)
+      let rhs: Int? = pure(x)
+
+      return lhs == rhs
+    }
+
+    property("alternative operator - right empty") <- forAll { (x: Int) in
+      let lhs: Int? = pure(x) <|> empty()
+      let rhs: Int? = pure(x)
+
+      return lhs == rhs
+    }
+
+    property("alternative operator - neither empty") <- forAll { (x: Int, y: Int) in
+      let lhs: Int? = pure(x) <|> pure(y)
+      let rhs: Int? = pure(x)
+
+      return lhs == rhs
+    }
+  }
+
   func testMonad() {
     // return x >>= f = f x
     property("left identity law") <- forAll { (x: Int, fa: ArrowOf<Int, Int>) in


### PR DESCRIPTION
Previously we were only implementing the bare minimum for Applicative.
However, we are already shipping <* and *> as operators, so there's
really no reason to not also ship default implementations for Optional
and Array.

Additionally, we're already shipping `<|>`, so we might as well
implement Alternative, which means implementing `empty` as well.