### PR TITLE
Rework README

### DIFF
--- a/Documentation/installation.md
+++ b/Documentation/installation.md
@@ -1,0 +1,35 @@
+# Framework Installation #
+
+## [Carthage] ##
+
+[Carthage]: https://github.com/Carthage/Carthage
+
+```
+github "thoughtbot/Runes"
+```
+
+Then run `carthage update`.
+
+Follow the current instructions in [Carthage's README][carthage-installation]
+for up to date installation instructions.
+
+[carthage-installation]: https://github.com/Carthage/Carthage#adding-frameworks-to-an-application
+
+## [CocoaPods] ##
+
+[CocoaPods]: http://cocoapods.org
+
+Add the following to your [Podfile](http://guides.cocoapods.org/using/the-podfile.html):
+
+```ruby
+pod 'Runes'
+```
+
+You will also need to make sure you're opting into using frameworks:
+
+```ruby
+use_frameworks!
+```
+
+Then run `pod install` with CocoaPods 0.36 or newer.
+

--- a/Documentation/version-compatibility.md
+++ b/Documentation/version-compatibility.md
@@ -1,0 +1,16 @@
+# Version Compatibility #
+
+Note that we're aggressive about pushing `master` forward along with new
+versions of Swift. Therefore, we highly recommend against pointing at
+`master`, and instead using [one of the releases we've provided][releases].
+
+Here is the current Swift compatibility breakdown:
+
+| Swift Version | Runes Version |
+| ------------- | ------------- |
+| 3.X           | 4.X           |
+| 2.X           | 3.X           |
+| 1.2           | 1.2, 2.X      |
+| 1.1           | < 1.2         |
+
+[releases]: https://github.com/thoughtbot/Runes/releases

--- a/README.md
+++ b/README.md
@@ -2,174 +2,86 @@
 
 Indecipherable symbols that some people claim have actual meaning.
 
+[![pod](https://img.shields.io/cocoapods/v/Runes.svg)](https://cocoapods.org/)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
+[![Swift Package Manager compatible](https://img.shields.io/badge/Swift%20Package%20Manager-compatible-brightgreen.svg)](https://github.com/apple/swift-package-manager)
 
-## Version Compatibility ##
+Please see [the documentation] for [version compatibility] and [installation]
+information.
 
-Note that we're aggressive about pushing `master` forward along with new
-versions of Swift. Therefore, we highly recommend against pointing at
-`master`, and instead using [one of the releases we've provided][releases].
-
-Here is the current Swift compatibility breakdown:
-
-| Swift Version | Runes Version |
-| ------------- | ------------- |
-| 3.X           | 4.X           |
-| 2.X           | 3.X           |
-| 1.2           | 1.2, 2.X      |
-| 1.1           | < 1.2         |
-
-[releases]: https://github.com/thoughtbot/Runes/releases
-
-## Framework Installation ##
-
-### [Carthage] ###
-
-[Carthage]: https://github.com/Carthage/Carthage
-
-```
-github "thoughtbot/Runes"
-```
-
-Then run `carthage update`.
-
-Follow the current instructions in [Carthage's README][carthage-installation]
-for up to date installation instructions.
-
-[carthage-installation]: https://github.com/Carthage/Carthage#adding-frameworks-to-an-application
-
-### [CocoaPods] ###
-
-[CocoaPods]: http://cocoapods.org
-
-Add the following to your [Podfile](http://guides.cocoapods.org/using/the-podfile.html):
-
-```ruby
-pod 'Runes'
-```
-
-You will also need to make sure you're opting into using frameworks:
-
-```ruby
-use_frameworks!
-```
-
-Then run `pod install` with CocoaPods 0.36 or newer.
-
-## Adding Runes as a Framework Dependency ##
-
-If you're a framework author, you might define your own custom types that
-would benefit from the operators defined in Runes. However, adding the entire
-Runes framework as a dependency might be too much overhead. In this case, you
-can use Carthage, CocoaPods, or Git to link to the file that defines the
-operators directly into your project. This will let you use Runes as a
-centralized dependency for the definition of the operators without needing to
-worry about additional overhead for your users.
-
-By using Runes as a dependency in this way, it will be easier to ensure
-compatibility between your operator definitions and other types. This will
-also reduce the amount of duplication of effort across projects that want to
-include the same kinds of functionality.
-
-In order to use Runes as a framework dependency, you must use git submodules.
-This will allow Carthage and CocoaPods to pull down the Runes source code
-without needing to expose the dependency to your users.
-
-### [Carthage] ###
-
-Add the following to `Cartfile.private`:
-
-```
-github "thoughtbot/Runes"
-```
-
-Then run `carthage update --no-use-binaries --use-submodules`. This will
-ensure that you don't get any pre-built binaries that we are providing for
-users who want the full `Runes.framework`, and will tell Carthage to set up a
-git submodule for you.
-
-Once you've checked out the required version, you can link
-`Carthage/Checkouts/Runes/Source/Runes.swift` directly into your framework.
-
-### [CocoaPods] ###
-
-After adding Runes as a git submodule, you will need to modify your podspec to
-tell CocoaPods to pull down your submodule dependencies. This is done by
-passing a `submodules: true` flag inside your spec's `source` property.
-
-For example, the `source` for [Argo]'s main spec would look like this:
-
-```ruby
-spec.source = {
-  git: "https://github.com/thoughtbot/Argo.git",
-  tag: "v#{s.version}",
-  submodules: true # add this line
-}
-```
-
-Then add `Runes.swift` to your spec's `source_files` property. This tells
-CocoaPods to include that file when building your framework.
-
-Again, using Argo as an example, we can make our `source_files` property look
-like so:
-
-```ruby
-spec.source_files = 'Argo/**/*.{h,swift}', 'Carthage/Checkouts/Runes/Source/Runes.swift'
-```
+[the documentation]: Documentation/
+[version compatibility]: Documentation/version-compatibility.md
+[installation]: Documentation/installation.md
 
 ## What's included? ##
 
-Importing Runes introduces several new operators and one global function:
+Importing Runes introduces several new operators and one global function that
+correspond to common Haskell typeclasses:
+
+### Functor ###
 
 - `<^>` (pronounced "map")
+
+### Applicative Functor ###
+
 - `<*>` (pronounced "apply")
+- `pure` (pronounced "pure")
+
+### Monad ###
+
 - `>>-` (pronounced "flatMap") (left associative)
 - `-<<` (pronounced "flatMap") (right associative)
-- `pure` (pronounced "pure")
 - `>->` (pronounced "Monadic compose") (left associative)
 - `<-<` (pronounced "Monadic compose") (right associative)
+
+### Implementations ###
 
 We also include default implementations for Optional and Array with the
 following type signatures:
 
 ```swift
-// Optional:
-public func <^><T, U>(f: T -> U, a: T?) -> U?
-public func <*><T, U>(f: (T -> U)?, a: T?) -> U?
-public func >>-<T, U>(a: T?, f: T -> U?) -> U?
-public func -<<<T, U>(f: T -> U?, a: T?) -> U?
-public func pure<T>(a: T) -> T?
-public func >-> <A, B, C>(f: A -> B?, g: B -> C?) -> A -> C?
-public func <-< <A, B, C>(f: B -> C?, g: A -> B?) -> A -> C?
+// Optional+Functor:
+public func <^> <T, U>(f: T -> U, x: T?) -> U?
 
-// Array:
-public func <^><T, U>(f: T -> U, a: [T]) -> [U]
-public func <*><T, U>(fs: [T -> U], a: [T]) -> [U]
-public func >>-<T, U>(a: [T], f: T -> [U]) -> [U]
-public func -<<<T, U>(f: T -> [U], a: [T]) -> [U]
-public func pure<T>(a: T) -> [T]
-public func >-> <A, B, C>(f: A -> [B], g: B -> [C]) -> A -> [C]
-public func <-< <A, B, C>(f: B -> [C], g: A -> [B]) -> A -> [C]
+// Optional+Applicative:
+public func <*> <T, U>(f: (T -> U)?, x: T?) -> U?
+public func pure<T>(x: T) -> T?
+
+// Optional+Monad:
+public func >>- <T, U>(x: T?, f: T -> U?) -> U?
+public func -<< <T, U>(f: T -> U?, x: T?) -> U?
+public func >-> <T, U, V>(f: T -> U?, g: U -> V?) -> T -> V?
+public func <-< <T, U, V>(f: U -> V?, g: T -> U?) -> T -> V?
+
+// Array+Functor:
+public func <^> <T, U>(f: T -> U, x: [T]) -> [U]
+
+// Array+Applicative:
+public func <*> <T, U>(fs: [T -> U], x: [T]) -> [U]
+public func pure<T>(x: T) -> [T]
+
+// Array+Monad:
+public func >>- <T, U>(x: [T], f: T -> [U]) -> [U]
+public func -<< <T, U>(f: T -> [U], x: [T]) -> [U]
+public func >-> <T, U, V>(f: T -> [U], g: U -> [V]) -> T -> [V]
+public func <-< <T, U, V>(f: U -> [V], g: T -> [U]) -> T -> [V]
 ```
 
-Contributing
-------------
+## Contributing ##
 
 See the [CONTRIBUTING] document. Thank you, [contributors]!
 
 [CONTRIBUTING]: CONTRIBUTING.md
 [contributors]: https://github.com/thoughtbot/Runes/graphs/contributors
 
-License
--------
+## License ##
 
 Runes is Copyright (c) 2015 thoughtbot, inc. It is free software, and may be
 redistributed under the terms specified in the [LICENSE] file.
 
 [LICENSE]: /LICENSE
 
-About
------
+## About ##
 
 ![thoughtbot](https://thoughtbot.com/logo.png)
 


### PR DESCRIPTION
The README was getting to be a sprawling inconsistent mess. I've done a
few things here:

- Started to break out the README into smaller documentation files.
Right now it's just the installation instructions and version
compatibility, but it's a start.
- Reorganize the functions we're exporting to make it a little easier to
read
- Standardize the markdown header format
- Add cocoapods and swift package manager badges for completeness