### PR TITLE
Add BITCODE_GENERATION_MODE user-defined build setting

### DIFF
--- a/Runes.xcodeproj/project.pbxproj
+++ b/Runes.xcodeproj/project.pbxproj
@@ -989,6 +989,7 @@
 		F802D4E91A5F218E005E236C /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BITCODE_GENERATION_MODE = marker;
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
@@ -1008,6 +1009,7 @@
 		F802D4EA1A5F218E005E236C /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BITCODE_GENERATION_MODE = bitcode;
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;


### PR DESCRIPTION
Release builds of the project failed due to absence of bitcode in the resulting framework. This change matches the approach in the Argo project for the iOS target. I don't know how to create a test for build settings like this. Please advise if you have suggestions.

Thanks for the great libraries!

-Don