### PR TITLE
Update project for Xcode 10.2

### DIFF
--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,2 +1,1 @@
 github "typelift/SwiftCheck" ~> 0.10.0
-github "gfontenot/Mozart" ~> 1.0.0

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,1 +1,1 @@
-github "typelift/SwiftCheck" ~> 0.10.0
+github "CodaFi/SwiftCheck" "fivel"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,1 @@
-github "gfontenot/Mozart" "v1.0.1"
 github "typelift/SwiftCheck" "0.10.0"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "typelift/SwiftCheck" "0.10.0"
+github "CodaFi/SwiftCheck" "acd322289d72206a761825071d066a447d472692"

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,25 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "FileCheck",
+        "repositoryURL": "https://github.com/llvm-swift/FileCheck.git",
+        "state": {
+          "branch": "swift-develop",
+          "revision": "38b60f755298fb5d857410b5530cedc9d9ca7db7",
+          "version": null
+        }
+      },
+      {
+        "package": "SwiftCheck",
+        "repositoryURL": "git@github.com:CodaFi/SwiftCheck.git",
+        "state": {
+          "branch": "fivel",
+          "revision": "acd322289d72206a761825071d066a447d472692",
+          "version": null
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,20 @@ import PackageDescription
 
 let package = Package(
   name: "Runes",
-  products: [.library(name: "Runes", targets: ["Runes"])],
-  dependencies: [],
-  targets: [.target(name: "Runes", dependencies: [], path: "Sources")]
+  products: [
+    .library(name: "Runes", targets: ["Runes"])
+  ],
+  dependencies: [
+    .package(url: "git@github.com:CodaFi/SwiftCheck.git", .branch("fivel"))
+  ],
+  targets: [
+    .target(name: "Runes"),
+    .testTarget(
+      name: "RunesTests",
+      dependencies: [
+        "Runes",
+        "SwiftCheck",
+      ]
+    ),
+  ]
 )

--- a/Package@swift-3.swift
+++ b/Package@swift-3.swift
@@ -1,0 +1,5 @@
+import PackageDescription
+
+let package = Package(
+  name: "Runes"
+)

--- a/Package@swift-4.swift
+++ b/Package@swift-4.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:4.0
 
 import PackageDescription
 

--- a/Package@swift-4.swift
+++ b/Package@swift-4.swift
@@ -4,7 +4,20 @@ import PackageDescription
 
 let package = Package(
   name: "Runes",
-  products: [.library(name: "Runes", targets: ["Runes"])],
-  dependencies: [],
-  targets: [.target(name: "Runes", dependencies: [], path: "Sources")]
+  products: [
+    .library(name: "Runes", targets: ["Runes"])
+  ],
+  dependencies: [
+    .package(url: "git@github.com:typelift/SwiftCheck.git", .from("0.11.0"))
+  ],
+  targets: [
+    .target(name: "Runes"),
+    .testTarget(
+      name: "RunesTests",
+      dependencies: [
+        "Runes",
+        "SwiftCheck",
+      ]
+    ),
+  ]
 )

--- a/Runes.xcodeproj/project.pbxproj
+++ b/Runes.xcodeproj/project.pbxproj
@@ -515,7 +515,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 0930;
+				LastUpgradeCheck = 1020;
 				ORGANIZATIONNAME = thoughtbot;
 				TargetAttributes = {
 					51DE8A111BAB363500124320 = {
@@ -550,10 +550,11 @@
 			};
 			buildConfigurationList = F802D4CC1A5F218E005E236C /* Build configuration list for PBXProject "Runes" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = F802D4C81A5F218E005E236C;
 			productRefGroup = F802D4D31A5F218E005E236C /* Products */;
@@ -875,6 +876,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -936,6 +938,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;

--- a/Runes.xcodeproj/project.pbxproj
+++ b/Runes.xcodeproj/project.pbxproj
@@ -27,12 +27,6 @@
 		F86B2E241A5F2B9E00C3B8BD /* Runes.h in Headers */ = {isa = PBXBuildFile; fileRef = F802D4D71A5F218E005E236C /* Runes.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F89776E51BA601D500EE823E /* SwiftCheck.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = F88DE9741BA3855600A9D383 /* SwiftCheck.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F89776E61BA601DE00EE823E /* SwiftCheck.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = F88DE9721BA3854E00A9D383 /* SwiftCheck.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		F89AAC901D74D00100184D08 /* Mozart.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F89AAC8F1D74D00100184D08 /* Mozart.framework */; };
-		F89AAC921D74D00E00184D08 /* Mozart.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F89AAC911D74D00E00184D08 /* Mozart.framework */; };
-		F89AAC941D74D01A00184D08 /* Mozart.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F89AAC931D74D01A00184D08 /* Mozart.framework */; };
-		F89AAC951D74D03C00184D08 /* Mozart.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = F89AAC931D74D01A00184D08 /* Mozart.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		F89AAC961D74D04300184D08 /* Mozart.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = F89AAC8F1D74D00100184D08 /* Mozart.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		F89AAC971D74D04800184D08 /* Mozart.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = F89AAC911D74D00E00184D08 /* Mozart.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F8D430A71D5A66A800548DF0 /* SwiftCheck.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = F80D6AE61D4BE1B800505CE9 /* SwiftCheck.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F8D430A81D5A670000548DF0 /* SwiftCheck.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F80D6AE61D4BE1B800505CE9 /* SwiftCheck.framework */; };
 		F8DDC6EA1DD6754600E173E0 /* Optional+Alternative.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8DDC6E91DD6754600E173E0 /* Optional+Alternative.swift */; };
@@ -104,7 +98,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				F89AAC951D74D03C00184D08 /* Mozart.framework in CopyFiles */,
 				F89776E61BA601DE00EE823E /* SwiftCheck.framework in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -115,7 +108,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				F89AAC961D74D04300184D08 /* Mozart.framework in CopyFiles */,
 				F89776E51BA601D500EE823E /* SwiftCheck.framework in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -126,7 +118,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				F89AAC971D74D04800184D08 /* Mozart.framework in CopyFiles */,
 				F8D430A71D5A66A800548DF0 /* SwiftCheck.framework in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -149,9 +140,6 @@
 		F86B2E0B1A5F2B8D00C3B8BD /* Runes.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Runes.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F88DE9721BA3854E00A9D383 /* SwiftCheck.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftCheck.framework; path = Carthage/Build/iOS/SwiftCheck.framework; sourceTree = SOURCE_ROOT; };
 		F88DE9741BA3855600A9D383 /* SwiftCheck.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftCheck.framework; path = Carthage/Build/Mac/SwiftCheck.framework; sourceTree = SOURCE_ROOT; };
-		F89AAC8F1D74D00100184D08 /* Mozart.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Mozart.framework; path = Carthage/Build/Mac/Mozart.framework; sourceTree = SOURCE_ROOT; };
-		F89AAC911D74D00E00184D08 /* Mozart.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Mozart.framework; sourceTree = "<group>"; };
-		F89AAC931D74D01A00184D08 /* Mozart.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Mozart.framework; path = Carthage/Build/iOS/Mozart.framework; sourceTree = SOURCE_ROOT; };
 		F8DDC6E91DD6754600E173E0 /* Optional+Alternative.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Optional+Alternative.swift"; sourceTree = "<group>"; };
 		F8DDC6EE1DD67D2600E173E0 /* Array+Alternative.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Array+Alternative.swift"; sourceTree = "<group>"; };
 		F8E09D151DCF83F200816E60 /* Array+Applicative.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Array+Applicative.swift"; sourceTree = "<group>"; };
@@ -177,7 +165,6 @@
 			files = (
 				51DE8A261BAB36E600124320 /* Runes.framework in Frameworks */,
 				F8D430A81D5A670000548DF0 /* SwiftCheck.framework in Frameworks */,
-				F89AAC921D74D00E00184D08 /* Mozart.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -201,7 +188,6 @@
 			files = (
 				F8624C2C1A645A9600C883B3 /* Runes.framework in Frameworks */,
 				F80721571D4BE47500882F0F /* SwiftCheck.framework in Frameworks */,
-				F89AAC941D74D01A00184D08 /* Mozart.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -211,7 +197,6 @@
 			files = (
 				F8624C4B1A645C9500C883B3 /* Runes.framework in Frameworks */,
 				F80721581D4BE48E00882F0F /* SwiftCheck.framework in Frameworks */,
-				F89AAC901D74D00100184D08 /* Mozart.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -275,7 +260,6 @@
 		F80D6AE51D4BE19E00505CE9 /* tvOS */ = {
 			isa = PBXGroup;
 			children = (
-				F89AAC911D74D00E00184D08 /* Mozart.framework */,
 				F80D6AE61D4BE1B800505CE9 /* SwiftCheck.framework */,
 			);
 			name = tvOS;
@@ -304,7 +288,6 @@
 		F8624C521A645CE200C883B3 /* iOS */ = {
 			isa = PBXGroup;
 			children = (
-				F89AAC931D74D01A00184D08 /* Mozart.framework */,
 				F88DE9721BA3854E00A9D383 /* SwiftCheck.framework */,
 			);
 			name = iOS;
@@ -313,7 +296,6 @@
 		F8624C531A645CF400C883B3 /* OS X */ = {
 			isa = PBXGroup;
 			children = (
-				F89AAC8F1D74D00100184D08 /* Mozart.framework */,
 				F88DE9741BA3855600A9D383 /* SwiftCheck.framework */,
 			);
 			name = "OS X";

--- a/Runes.xcodeproj/xcshareddata/xcschemes/Runes-Mac.xcscheme
+++ b/Runes.xcodeproj/xcshareddata/xcschemes/Runes-Mac.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Runes.xcodeproj/xcshareddata/xcschemes/Runes-iOS.xcscheme
+++ b/Runes.xcodeproj/xcshareddata/xcschemes/Runes-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Runes.xcodeproj/xcshareddata/xcschemes/Runes-tvOS.xcscheme
+++ b/Runes.xcodeproj/xcshareddata/xcschemes/Runes-tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Runes.xcodeproj/xcshareddata/xcschemes/Runes-watchOS.xcscheme
+++ b/Runes.xcodeproj/xcshareddata/xcschemes/Runes-watchOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Tests/RunesTests/ArraySpec.swift
+++ b/Tests/RunesTests/ArraySpec.swift
@@ -1,6 +1,5 @@
 import XCTest
 import SwiftCheck
-import Mozart
 import Runes
 
 class ArraySpec: XCTestCase {

--- a/Tests/RunesTests/Functions.swift
+++ b/Tests/RunesTests/Functions.swift
@@ -9,3 +9,17 @@ func id<A>(_ a: A) -> A {
 func curry<A, B, C>(_ f: @escaping (A, B) -> C) -> (A) -> (B) -> C {
   return { a in { b in f(a, b) }}
 }
+
+func compose<T, U, V>(_ f: @escaping (U) -> V, _ g: @escaping (T) -> U) -> (T) -> V {
+  return { x in f(g(x)) }
+}
+
+precedencegroup CompositionPrecedence {
+  associativity: right
+  higherThan: BitwiseShiftPrecedence
+}
+
+infix operator • : CompositionPrecedence
+func • <T, U, V>(f: @escaping (U) -> V, g: @escaping (T) -> U) -> (T) -> V {
+  return compose(f, g)
+}

--- a/Tests/RunesTests/OptionalSpec.swift
+++ b/Tests/RunesTests/OptionalSpec.swift
@@ -1,6 +1,5 @@
 import XCTest
 import SwiftCheck
-import Mozart
 import Runes
 
 class OptionalSpec: XCTestCase {


### PR DESCRIPTION
No source changes needed here, but this gets Runes building properly with
Xcode 10.2/Swift 5.

Not sure how this should be versioned, tbh. This technically acts as a
breaking change for Carthage users since we're updating the swift version, but
it's _not_ a breaking change for anyone else because the source doesn't
change. If anyone has opinions here I'd sure appreciate hearing them.