### PR TITLE
Autoclosure blocks cannot be passed as an argument to other function …

### DIFF
--- a/Sources/Runes/Optional/Optional+Alternative.swift
+++ b/Sources/Runes/Optional/Optional+Alternative.swift
@@ -11,7 +11,7 @@
   - returns: a value of type `Optional<T>`
 */
 public func <|> <T>(lhs: T?, rhs: @autoclosure () -> T?) -> T? {
-  return lhs.or(rhs)
+  return lhs.or(rhs())
 }
 
 /**


### PR DESCRIPTION
…in Swift 5

Fixes #100 