### PR TITLE
Update Swift Version Compatibility

### DIFF
--- a/Documentation/version-compatibility.md
+++ b/Documentation/version-compatibility.md
@@ -8,7 +8,7 @@ Here is the current Swift compatibility breakdown:
 
 | Swift Version | Runes Version |
 | ------------- | ------------- |
-| 3.X           | 4.X           |
+| 3.X -> 5.X    | 4.X           |
 | 2.X           | 3.X           |
 | 1.2           | 1.2, 2.X      |
 | 1.1           | < 1.2         |

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.2.1</string>
+	<string>4.2.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Runes.podspec
+++ b/Runes.podspec
@@ -1,6 +1,7 @@
 Pod::Spec.new do |spec|
   spec.name = 'Runes'
   spec.version = '4.2.2'
+  spec.swift_versions = ['3.0', '4.0', '4.2', '5.0']
   spec.summary = 'Functional operators for Swift'
   spec.homepage = 'https://github.com/thoughtbot/runes'
   spec.license = { :type => 'MIT', :file => 'LICENSE' }

--- a/Runes.podspec
+++ b/Runes.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = 'Runes'
-  spec.version = '4.2.1'
+  spec.version = '4.2.2'
   spec.summary = 'Functional operators for Swift'
   spec.homepage = 'https://github.com/thoughtbot/runes'
   spec.license = { :type => 'MIT', :file => 'LICENSE' }


### PR DESCRIPTION
Our compatibility matrix was out of date, and the podspec didn't specify any
swift versions, which was causing a massive headache when trying to publish
new versions.